### PR TITLE
Version 13.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ While the focus of the app has changed to command line automation, the forms GUI
 
 There are several ways to create a build package from the command line.  Which you choose depends on your starting point:
 
+[Command line reference](docs/commandline.md)
+
 1. From a DACPAC file using the `sbm scriptextract` command. This method leverages a DACPAC that was created against your "Platinum Database" (why platinum? because it's even more precious than gold!). The Platinum database should have the schema that you want all of your other databases to look like. (don't have a DACPAC created, don't worry, you can create one with the `sbm dacpac` command) Learn more about DACPACs and [data-tier applications](https://docs.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-2017)  method.
 
-2. From a set of script files using `sbm create`. This command allows you to specify an `--outputsbm` file to be created and a list of `--scripts` files to populate the SBM file with.
+2. From a set of script files using `sbm create`. This command allows you to specify an `--outputsbm` file to be created and a list of `--scripts` files to populate the SBM file with. 
 
 3. From an SBX file. What is this? An SBX file is an XML file in the format of the `SqlSyncBuildProject.xml` file (see above) that has an `.sbx` extension. When you use the `sbm package` command, it will read the `.sbx` file and create the `.sbm` file with the referenced scripts.
 
 4. An SBM package file can be created indirectly as well, using the `sbm threaded run` and `sbm batch run` commands along with the `--platinumdbsource="<database name>"` and `--platinumserversource="<server name>"` the app will generate a DACPAC from the source database which will then be used to generate an SBM at run time to build directly on your target(s).
+
+You can also add new scripts to an existing SBM package or SBX project file using `sbm add`
 
 ----
 

--- a/docs/azure_batch_commands.md
+++ b/docs/azure_batch_commands.md
@@ -8,7 +8,7 @@ This utility action will save a reusable JSON file to make running the command l
 
 The next time you run a build action, use the `--settingsfile="<file path>"` in place of the arguments below.
 
-Can also optionally provide a `--settingsfilekey` value to provide a custom encryption key for encryption of the sensitive values (listed below). The value for the `--settingsfilekey`  can be either the encryption key itself of a path to a text file containing the key.
+Can also optionally provide a `--settingsfilekey` value to provide a custom encryption key for encryption of the sensitive values (listed below). The value for the `--settingsfilekey`  can be either the encryption key itself or the path to a text file containing the key.
 
 - Authentication: `--username`, `--password`
 - Azure Batch: `--batchnodecount`, `--batchaccountname`, `--batchaccountkey`, `--batchaccounturl`, `--storageaccountname`, `--storageaccountkey`, `--batchvmsize`, `--deletebatchpool`, `--deletebatchjob`, `--pollbatchpoolstatus`, `--eventhubconnectionstring`

--- a/docs/change_notes.md
+++ b/docs/change_notes.md
@@ -2,13 +2,20 @@
 # SQL Build Manager Change Notes
 
 
+### Version 13.0.4
+
+- *ADDED:* New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts
+- *ADDED:* New command `sbm list` to output script information of SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)
+- *UPDATED:* The `sbm create` command can now also create an SBX project file, not just an SBM package
+- *UPDATED:* Tabular output for `sbm policycheck` command to make it easier to read. Defaulting enterprise config to GitHub file.
+
 ### Version 13.0.3
 
 - *FIXED:* Update to Dacpac change scripts to identify new header delimiter
-- *FIXED:* Issue creating scripts between incompatable SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` 
+- *FIXED:* Issue creating scripts between incompatible SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` 
 - *ADDED:* New command `sbm create` to create a new SBM file from a list of scripts
-- *UPDATED:* Can now use Windows auth for DACPAC creation
-- *UPDATED:* updated Nuget packages
+- *UPDATED:* Can now use Windows authentication for DACPAC creation
+- *UPDATED:* updated NuGet packages
 
 ### Version 13.0.2
 
@@ -38,7 +45,7 @@
 - **NOTE:** **Removed old style command line (leveraging the `/Action=verb` flag etc.). Run `sbm --help` for instructions**
 - **NOTE:** Now built against .NET 5 and .NET Core 3.1
 - *ADDED:* New `threaded` and `batch` command options: `--concurrency` and `--concurrencytype`. See docs on [Concurrency Options](concurrency_options.md)
-- *UPDATED:* Now leveraging `Microsoft.SqlServer.DACFx` Nuget package instead of `sqlpackage.exe` command line to manage DACPACs
+- *UPDATED:* Now leveraging `Microsoft.SqlServer.DACFx` NuGet package instead of `sqlpackage.exe` command line to manage DACPACs
 - *FIXED:* Updated `BlueSkyDev.Logging.AzureEventHubAppender` to v1.3.2 due to app hanging if EventHub connection string was incorrect
 
 ### Version 11.3.1
@@ -77,7 +84,7 @@
 ### Version 10.4.4
 
 - *ADDED:* Added command line argument `/DefaultScriptTimeout` (integer) to allow custom settings for the timeout of scripts when created from a DACPAC. Default is 500 seconds
-- *UPDATED:* Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that reults in a build rollback
+- *UPDATED:* Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that results in a build rollback
 
 ### Version 10.4.3
 
@@ -163,7 +170,7 @@
 ### Version 10.1.1
 
 - *ADDED:* Added console argument /AzureRemoteStatus=true to list Azure remote execution machines and their readiness status
-- *ADDED:* Added console argument /ForceCustomDacPac=true to force teh creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity
+- *ADDED:* Added console argument /ForceCustomDacPac=true to force the creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity
 - *FIXED:* Various remote/ threaded bug fixes
 
 ### Version 10.1.0
@@ -188,7 +195,7 @@
 ### Version 9.2.1
 
 - *ADDED:* New policy check status that warns you that code should be reviewed before release
-- *ADDED:* command line abilty to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "<Source Package Path and Name>" 
+- *ADDED:* command line ability to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "<Source Package Path and Name>" 
 - *ADDED:* command line ability to create a default backout package. Usage: `SqlBuildManager.Console.exe /CreateBackout "<Source Package Path and Name>" /server="<Backout source server>" /database="<Backout source database>`"
 - *FIXED:* Script policy icons were getting set to "Policy checks not run" after a committed build
 - *FIXED:* Database login error for accounts that do not have code review database permissions
@@ -231,7 +238,7 @@
 ### Version 8.8.0.1
 
 - *ADDED:* Integration with Source Control! New notification area indicator if project and files are under source control.
-- **NOTE:**  *Will Checkout and Add files only*   You will still need to checkin/commit your changes manually
+- **NOTE:**  *Will Checkout and Add files only*   You will still need to check-in/commit your changes manually
 - *UPDATED:* Compiled against Version 11 of Server Management Objects (SMO) for compatibility with SQL 2012
 - *UPDATED:* Improved threading when adding scripted files to ensure no dialog windows are "lost"
 - *ADDED:* Will now accept WITH (READPAST) as valid query optimization. This should only be used in distinct use cases!

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -15,9 +15,11 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 
 ### Utility actions
 
-- `dacpac` - Create a DACPAC file from the source `--database` and `--server`
-- `create` - Creates an SBM package file from a list of supplied script files
+- `create` - Creates an SBM package or SBX project file from a list of supplied script files
+- `add` - Adds scripts to an existing SBM package or SBX project file
 - `package` - Creates an SBM package from an SBX configuration file and scripts
+- `list` - Output scripts information on SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)
+- `dacpac` - Create a DACPAC file from the source `--database` and `--server`
 - `policycheck` - Performs a script policy check on the specified SBM package
 - `gethash` - Calculates the SHA-1 hash fingerprint value for the SBM package(scripts + run order)
 - `createbackout` - Generates a back out package (reversing stored procedure and scripted object changes)
@@ -44,7 +46,7 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 
 ----
 
- ## Logging
+## Logging
 
 For general logging, the
 SqlBuildManager.Console.exe has its own local messages. This log file is
@@ -92,4 +94,3 @@ run order and results.
 - `SqlSyncBuildProject.xml`: the XML file showing the design time
 meta-data on each script file that defined the run settings, script
 creation user ID's and the committed script record and hash for each.
-	

--- a/src/AssemblyVersioning.cs
+++ b/src/AssemblyVersioning.cs
@@ -25,7 +25,7 @@
 //   These can be found in SqlBuildManager.Setup -> Organize Your Setup -> General Information
 // ** Also, don't forget to update the change_notes.xml and .html files!
 
-[assembly: AssemblyVersion("13.0.3")]
-[assembly: AssemblyFileVersion("13.0.3")]
+[assembly: AssemblyVersion("13.0.4")]
+[assembly: AssemblyFileVersion("13.0.4")]
 
 

--- a/src/SqlBuildManager.Console/sbm.csproj
+++ b/src/SqlBuildManager.Console/sbm.csproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\SqlSync.SqlBuild\SqlSync.SqlBuild.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.1.2" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.5164.1" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.1.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="4.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
   </ItemGroup>
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/SqlBuildManager.Enterprise/EnterpriseConfigHelper.cs
+++ b/src/SqlBuildManager.Enterprise/EnterpriseConfigHelper.cs
@@ -66,7 +66,7 @@ namespace SqlBuildManager.Enterprise
             }
             else
             {
-                return LoadEnterpriseConfiguration(@"C:\force_a_local_file_check");
+                return LoadEnterpriseConfiguration(@"https://raw.githubusercontent.com/mmckechney/SqlBuildManager/master/src/SqlBuildManager.Enterprise/EnterpriseConfiguration.xml");
             }
 
         }
@@ -76,7 +76,10 @@ namespace SqlBuildManager.Enterprise
             string configuration = string.Empty;
             try
             {
-                configPath = Path.GetFullPath(configPath);
+                if (!configPath.ToLower().StartsWith("http"))
+                {
+                    configPath = Path.GetFullPath(configPath);
+                }
                 System.Net.WebRequest req = System.Net.WebRequest.Create(configPath);
                 req.Proxy = System.Net.WebRequest.DefaultWebProxy;
                 req.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;

--- a/src/SqlBuildManager.Enterprise/EnterpriseConfiguration.xml
+++ b/src/SqlBuildManager.Enterprise/EnterpriseConfiguration.xml
@@ -1,23 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <EnterpriseConfiguration xmlns="http://www.mckechney.com/EnterpriseConfiguration.xsd">
-	<TableWatch Description="Sample Table Watch" EmailBody="One of your watched tables has changed" EmailSubject="Alert Notice">
-		<Table Name="SqlBuild_logging" />
-		<Table Name="TransactionTest" />
-		<Notify EMail="michael@mckechney.com" Name="Michael McKechney"/>
-		<Notify EMail="help@sqlbuildmanager.com" Name="Sql Build Admin"/>
-	</TableWatch>
-	<ScriptPolicy PolicyId="CommentHeaderPolicy" Severity="Low"/>
-	<ScriptPolicy PolicyId="ConstraintNamePolicy" Severity="Low"/>
+  <TableWatch Description="Sample Table Watch" EmailBody="One of your watched tables has changed" EmailSubject="Alert Notice">
+    <Table Name="SqlBuild_logging" />
+    <Table Name="TransactionTest" />
+    <Notify EMail="michael@mckechney.com" Name="Michael McKechney"/>
+    <Notify EMail="help@sqlbuildmanager.com" Name="Sql Build Admin"/>
+  </TableWatch>
+        <ScriptPolicy PolicyId="CommentHeaderPolicy" Severity="Low"/>
+        <ScriptPolicy PolicyId="ConstraintNamePolicy"Severity="Low"/> 
 	<ScriptPolicy PolicyId="GrantExecutePolicy" Severity="High"/>
 	<ScriptPolicy PolicyId="GrantExecuteToPublicPolicy" Severity="High"/>
 	<ScriptPolicy PolicyId="QualifiedNamesPolicy" Severity="Medium"/>
 	<ScriptPolicy PolicyId="ReRunablePolicy" Severity="Medium"/>
 	<ScriptPolicy PolicyId="SelectStarPolicy" Severity="Medium"/>
+    <Argument Name="SystemExceptionRegex" Value="SELECT\s*\*\s*FROM\s*sys"/>
+    <Argument Name="ViewExceptionRegex" Value="SELECT((\s*)|(\s*.*\.))\*\s*FROM((\s*)|(\s*.*\.))vw_\w"/>
+  </ScriptPolicy>
 	<ScriptPolicy PolicyId="StoredProcParameterPolicy" Severity="Medium">
-		<Argument Name="Schema" Value="xyz"/>
-		<Argument Name="Parameter" Value="@CustomerId"/>
-	</ScriptPolicy>
+    <Argument Name="Schema" Value="xyz"/>
+    <Argument Name="Parameter" Value="@CustomerId"/>
+  </ScriptPolicy>
 	<ScriptPolicy PolicyId="WithNoLockPolicy" Severity="High"/>
-	
-	<FeatureAccess FeatureId="RemoteExecution" Enabled="true"/>
+  <ScriptPolicy PolicyId="ViewAlterPolicy"/>
+  <ScriptPolicy PolicyId="ScriptSyntaxCheckPolicy">
+    <ScriptPolicyDescription LongDescription="Checks for 'EXECUTE AS' directives which are not allowed"
+								 ShortDescription="EXECUTE AS"
+								 ErrorMessage="An 'EXECUTE AS' directive was found on line {lineNumber}. This is not allowed - please remove it."/>
+    <Argument Name="ExecuteAs" Value="EXECUTE AS" />
+  </ScriptPolicy>
+  <ScriptPolicy PolicyId="ScriptSyntaxCheckPolicy">
+    <ScriptPolicyDescription LongDescription="Checks for 'WITH RECOMPILE' directives which are not allowed"
+								 ShortDescription="WITH RECOMPILE"
+								 ErrorMessage="A 'WITH RECOMPILE' directive was found on line {lineNumber}. This is not allowed - please remove it."/>
+    <Argument Name="WithRecompile" Value="WITH RECOMPILE" />
+  </ScriptPolicy>
+
 </EnterpriseConfiguration>

--- a/src/SqlBuildManager.Enterprise/Policy/PolicyHelper.cs
+++ b/src/SqlBuildManager.Enterprise/Policy/PolicyHelper.cs
@@ -292,7 +292,7 @@ namespace SqlBuildManager.Enterprise.Policy
             {
                 try
                 {
-                    string scriptContents = File.ReadAllText(extractedProjectPath + row.FileName);
+                    string scriptContents = File.ReadAllText(Path.Combine(extractedProjectPath,row.FileName));
                     scriptItem = this.ValidateScriptAgainstPolicies(row.FileName, row.ScriptId, scriptContents, row.Database, 80);
                     if (scriptItem == null)
                     {
@@ -392,11 +392,11 @@ namespace SqlBuildManager.Enterprise.Policy
             return line;
         }
 
-        public List<string> CommandLinePolicyCheck(string buildPackageName, out bool passed)
+        public List<string[]> CommandLinePolicyCheck(string buildPackageName, out bool passed)
         {
             string highSeverity = ViolationSeverity.High.ToString();
             passed = true;
-            List<string> policyReturns = new List<string>();
+            List<string[]> policyReturns = new List<string[]>();
             SqlSyncBuildData buildData = null;
 
             if (String.IsNullOrEmpty(buildPackageName))
@@ -435,16 +435,16 @@ namespace SqlBuildManager.Enterprise.Policy
 
                 foreach (var violation in violationMessages)
                 {
-                    string message = string.Format("Severity [{0}]; Script: {1}; Message: {2}",violation.Severity, violation.ScriptName, violation.Message);
-                    policyReturns.Add(message);
+                    policyReturns.Add(new string[] { violation.Severity, violation.ScriptName, violation.Message });
 
-                    //Add messages to log
-                    if(violation.Severity == ViolationSeverity.High.ToString())
-                        log.LogError(message);   
-                    else if(violation.Severity == ViolationSeverity.Medium.ToString())
-                        log.LogWarning(message);
-                    else 
-                        log.LogInformation(message);
+                    //string message = string.Format($"Severity [{violation.Severity}]; Script: {violation.ScriptName}; Message: {violation.Message}");
+                    ////Add messages to log
+                    //if (violation.Severity == ViolationSeverity.High.ToString())
+                    //    log.LogError(message);   
+                    //else if(violation.Severity == ViolationSeverity.Medium.ToString())
+                    //    log.LogWarning(message);
+                    //else 
+                    //    log.LogInformation(message);
                 }
                 return policyReturns;   
             }

--- a/src/SqlBuildManager.Logging/SqlBuildManager.Logging.csproj
+++ b/src/SqlBuildManager.Logging/SqlBuildManager.Logging.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.4.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.1.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.2.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="Serilog.Sinks.AzureEventHub" Version="6.0.0-dev-00060" />

--- a/src/SqlSync.SqlBuild/BuildDataHelper.cs
+++ b/src/SqlSync.SqlBuild/BuildDataHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+
+namespace SqlSync.SqlBuild
+{
+    public class BuildDataHelper
+    {
+        public static void GetLastBuildNumberAndDb(SqlSyncBuildData buildData, out double lastbuildNumber, out string lastDatabase)
+        {
+            //Use the dataset to get the last build number and Db
+            if (buildData != null && buildData.Script.Rows.Count > 0)
+            {
+                DataView view = buildData.Script.DefaultView;
+                view.RowFilter = buildData.Script.BuildOrderColumn.ColumnName + " < " + ((int)ResequenceIgnore.StartNumber).ToString();
+                view.Sort = buildData.Script.BuildOrderColumn + " DESC";
+                if (view.Count > 0)
+                {
+                    lastbuildNumber = ((SqlSyncBuildData.ScriptRow)view[0].Row).BuildOrder;
+                    lastDatabase = ((SqlSyncBuildData.ScriptRow)view[0].Row).Database;
+                }
+                else
+                {
+                    lastbuildNumber = 0;
+                    lastDatabase = "";
+                }
+
+                return;
+            }
+
+            lastbuildNumber = 0;
+            lastDatabase = string.Empty;
+            return;
+        }
+    }
+}

--- a/src/SqlSync.SqlBuild/SqlBuildFileHelper.cs
+++ b/src/SqlSync.SqlBuild/SqlBuildFileHelper.cs
@@ -339,18 +339,18 @@ namespace SqlSync.SqlBuild
         }
 
 
-		public static void SaveSqlBuildProjectFile(ref SqlSyncBuildData buildData, string projFileName, string buildZipFileName)
+		public static void SaveSqlBuildProjectFile(ref SqlSyncBuildData buildData, string projFileName, string buildZipFileName, bool includeHistoryAndLogs = true)
 		{
 			buildData.WriteXml(projFileName);
-			PackageProjectFileIntoZip(buildData,Path.GetDirectoryName(projFileName), buildZipFileName);
+			PackageProjectFileIntoZip(buildData,Path.GetDirectoryName(projFileName), buildZipFileName, includeHistoryAndLogs);
 		}
 
-        public static bool SaveSqlFilesToNewBuildFile(string buildFileName, List<string> fileNames, string targetDatabaseName, int defaultScriptTimeout)
+        public static bool SaveSqlFilesToNewBuildFile(string buildFileName, List<string> fileNames, string targetDatabaseName, int defaultScriptTimeout, bool includeHistoryAndLogs = true)
         {
-            return SaveSqlFilesToNewBuildFile(buildFileName, fileNames, targetDatabaseName, false, defaultScriptTimeout);
+            return SaveSqlFilesToNewBuildFile(buildFileName, fileNames, targetDatabaseName, false, defaultScriptTimeout, false);
         }
 
-        public static bool SaveSqlFilesToNewBuildFile(string buildFileName, List<string> fileNames, string targetDatabaseName, bool overwritePreExistingFile, int defaultScriptTimeout)
+        public static bool SaveSqlFilesToNewBuildFile(string buildFileName, List<string> fileNames, string targetDatabaseName, bool overwritePreExistingFile, int defaultScriptTimeout, bool includeHistoryAndLogs = true)
         {
             if (File.Exists(buildFileName) && !overwritePreExistingFile)
             {
@@ -391,7 +391,7 @@ namespace SqlSync.SqlBuild
                         defaultScriptTimeout, "");
 
                 }
-                SqlBuildFileHelper.SaveSqlBuildProjectFile(ref buildData, projFileName, buildFileName);
+                SqlBuildFileHelper.SaveSqlBuildProjectFile(ref buildData, projFileName, buildFileName, includeHistoryAndLogs);
                 return true;
             }
             catch(Exception exe)
@@ -1550,5 +1550,7 @@ namespace SqlSync.SqlBuild
             }
         }
         #endregion
+
+       
     }
 }

--- a/src/SqlSync/App.config
+++ b/src/SqlSync/App.config
@@ -21,7 +21,7 @@
     <add key="ProgramUpdateContact" value="Michael McKechney"/>
     <add key="ProgramUpdateContactEMail" value="michael@mckechney.com"/>
     <add key="ClientSettingsProvider.ServiceUri" value=""/>
-    <add key="Enterprise.ConfigFileLocation" value="I:\mmckechney\Sql Build Manager\Enterprise\EnterpriseConfiguration.xml"/>
+    <add key="Enterprise.ConfigFileLocation" value="https://raw.githubusercontent.com/mmckechney/SqlBuildManager/master/src/SqlBuildManager.Enterprise/EnterpriseConfiguration.xml"/>
   </appSettings>
   
   <!--<system.web>

--- a/src/SqlSync/SQLSync.csproj
+++ b/src/SqlSync/SQLSync.csproj
@@ -352,7 +352,7 @@
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.5164.1" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.1.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />

--- a/src/SqlSync/SqlBuild/SqlBuildForm.cs
+++ b/src/SqlSync/SqlBuild/SqlBuildForm.cs
@@ -41,6 +41,7 @@ using SqlSync.TableScript;
 using SqlSync.Validator;
 using Microsoft.Extensions.Logging;
 using SqlBuildManager.Logging;
+using sb = SqlSync.SqlBuild;
 //using SqlBuildManager.Enterprise.CodeReview;
 namespace SqlSync.SqlBuild
 
@@ -3941,32 +3942,7 @@ namespace SqlSync.SqlBuild
             return false;
 
         }
-        private void GetLastBuildNumberAndDb(out double lastbuildNumber, out string lastDatabase)
-        {
-            //Use the dataset to get the last build number and Db
-            if (this.buildData != null && this.buildData.Script.Rows.Count > 0)
-            {
-                DataView view = this.buildData.Script.DefaultView;
-                view.RowFilter = this.buildData.Script.BuildOrderColumn.ColumnName + " < " + ((int)ResequenceIgnore.StartNumber).ToString();
-                view.Sort = this.buildData.Script.BuildOrderColumn + " DESC";
-                if (view.Count > 0)
-                {
-                    lastbuildNumber = ((SqlSyncBuildData.ScriptRow)view[0].Row).BuildOrder;
-                    lastDatabase = ((SqlSyncBuildData.ScriptRow)view[0].Row).Database;
-                }
-                else
-                {
-                    lastbuildNumber = 0;
-                    lastDatabase = "";
-                }
-
-                return;
-            }
-
-            lastbuildNumber = 0;
-            lastDatabase = string.Empty;
-            return;
-        }
+      
 
         #endregion
 
@@ -4807,7 +4783,7 @@ namespace SqlSync.SqlBuild
             string lastDatabase = string.Empty;
             string shortFileName = Path.GetFileName(fullFileName);
 
-            GetLastBuildNumberAndDb(out lastBuildNumber, out lastDatabase);
+            BuildDataHelper.GetLastBuildNumberAndDb(this.buildData, out lastBuildNumber, out lastDatabase);
 
             NewBuildScriptForm frmNew = new NewBuildScriptForm(this.projectFilePath, fullFileName, this.databaseList, lastBuildNumber, lastDatabase, System.Environment.UserName, this.tagList);
             DialogResult result2 = frmNew.ShowDialog();
@@ -5265,7 +5241,7 @@ namespace SqlSync.SqlBuild
             string lastDatabase = string.Empty;
 
             SqlSyncBuildData.ScriptRow newRow = this.buildData.Script.NewScriptRow();
-            GetLastBuildNumberAndDb(out lastBuildNumber, out lastDatabase);
+            sb.BuildDataHelper.GetLastBuildNumberAndDb(this.buildData, out lastBuildNumber, out lastDatabase);
             newRow.Database = lastDatabase;
             newRow.BuildOrder = Math.Floor(lastBuildNumber + 1);
             newRow.CausesBuildFailure = true;
@@ -5576,7 +5552,7 @@ namespace SqlSync.SqlBuild
             string lastDatabase;
             for (int i = 0; i < fileNames.Length; i++)
             {
-                GetLastBuildNumberAndDb(out lastBuildNumber, out lastDatabase);
+                sb.BuildDataHelper.GetLastBuildNumberAndDb(this.buildData, out lastBuildNumber, out lastDatabase);
 
                 double importStartNumber = ImportSqlScriptFile(fileNames[i], lastBuildNumber, out addedFileNames);
                 if (importStartNumber > 0)
@@ -5793,7 +5769,7 @@ namespace SqlSync.SqlBuild
         {
             double lastBuildNumber;
             string lastDatabase;
-            GetLastBuildNumberAndDb(out lastBuildNumber, out lastDatabase);
+            sb.BuildDataHelper.GetLastBuildNumberAndDb(this.buildData, out lastBuildNumber, out lastDatabase);
 
             //Get the last whole number since we initially add 1
             lastBuildNumber = Math.Floor(lastBuildNumber);
@@ -7634,7 +7610,7 @@ namespace SqlSync.SqlBuild
 
                 double lastBuildNumber;
                 string lastDb;
-                GetLastBuildNumberAndDb(out lastBuildNumber, out lastDb);
+                sb.BuildDataHelper.GetLastBuildNumberAndDb(this.buildData, out lastBuildNumber, out lastDb);
 
                 SqlSync.Analysis.ComparisonForm frmCompare = new SqlSync.Analysis.ComparisonForm(ref this.buildData, lastBuildNumber, this.buildZipFileName, this.projectFilePath, rightFile, true);
                 frmCompare.ShowDialog();

--- a/src/SqlSync/change_notes.html
+++ b/src/SqlSync/change_notes.html
@@ -39,17 +39,27 @@
   </head>
   <body>
     <h1>SQL Build Manager Change Notes</h1>
+    <div class="version">Version 13.0.4</div>
+    <div>
+      <span class="added">ADDED: </span>New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts</div>
+    <div>
+      <span class="added">ADDED: </span>New command `sbm list` to output script information of SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)</div>
+    <div>
+      <span class="updated">UPDATED: </span>The `sbm create` command can now also create an SBX project file, not just an SBM package</div>
+    <div>
+      <span class="updated">UPDATED: </span>Tabular output for `sbm policycheck` command to make it easier to read. Defaulting enterprise config to GitHub file.</div>
+    <br />
     <div class="version">Version 13.0.3</div>
     <div>
       <span class="fixed">FIXED: </span>Update to Dacpac change scripts to identify new header delimiter</div>
     <div>
-      <span class="fixed">FIXED: </span>Issue creating scripts between incompatable SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` </div>
+      <span class="fixed">FIXED: </span>Issue creating scripts between incompatible SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` </div>
     <div>
       <span class="added">ADDED: </span>New command `sbm create` to create a new SBM file from a list of scripts</div>
     <div>
-      <span class="updated">UPDATED: </span>Can now use Windows auth for DACPAC creation</div>
+      <span class="updated">UPDATED: </span>Can now use Windows authentication for DACPAC creation</div>
     <div>
-      <span class="updated">UPDATED: </span>updated Nuget packages</div>
+      <span class="updated">UPDATED: </span>updated NuGet packages</div>
     <br />
     <div class="version">Version 13.0.2</div>
     <div>
@@ -89,7 +99,7 @@
     <div>
       <span class="added">ADDED: </span>New `threaded` and `batch` command options: `--concurrency` and `--concurrencytype`. See docs on [Concurrency Options](concurrency_options.md)</div>
     <div>
-      <span class="updated">UPDATED: </span>Now leveraging `Microsoft.SqlServer.DACFx` Nuget package instead of `sqlpackage.exe` command line to manage DACPACs</div>
+      <span class="updated">UPDATED: </span>Now leveraging `Microsoft.SqlServer.DACFx` NuGet package instead of `sqlpackage.exe` command line to manage DACPACs</div>
     <div>
       <span class="fixed">FIXED: </span>Updated `BlueSkyDev.Logging.AzureEventHubAppender` to v1.3.2 due to app hanging if EventHub connection string was incorrect</div>
     <br />
@@ -142,7 +152,7 @@
     <div>
       <span class="added">ADDED: </span>Added command line argument `/DefaultScriptTimeout` (integer) to allow custom settings for the timeout of scripts when created from a DACPAC. Default is 500 seconds</div>
     <div>
-      <span class="updated">UPDATED: </span>Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that reults in a build rollback</div>
+      <span class="updated">UPDATED: </span>Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that results in a build rollback</div>
     <br />
     <div class="version">Version 10.4.3</div>
     <div>
@@ -246,7 +256,7 @@
     <div>
       <span class="added">ADDED: </span>Added console argument /AzureRemoteStatus=true to list Azure remote execution machines and their readiness status</div>
     <div>
-      <span class="added">ADDED: </span>Added console argument /ForceCustomDacPac=true to force teh creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity</div>
+      <span class="added">ADDED: </span>Added console argument /ForceCustomDacPac=true to force the creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity</div>
     <div>
       <span class="fixed">FIXED: </span>Various remote/ threaded bug fixes</div>
     <br />
@@ -280,7 +290,7 @@
     <div>
       <span class="added">ADDED: </span>New policy check status that warns you that code should be reviewed before release</div>
     <div>
-      <span class="added">ADDED: </span>command line abilty to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "&lt;Source Package Path and Name&gt;" </div>
+      <span class="added">ADDED: </span>command line ability to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "&lt;Source Package Path and Name&gt;" </div>
     <div>
       <span class="added">ADDED: </span>command line ability to create a default backout package. Usage: `SqlBuildManager.Console.exe /CreateBackout "&lt;Source Package Path and Name&gt;" /server="&lt;Backout source server&gt;" /database="&lt;Backout source database&gt;`"</div>
     <div>
@@ -346,7 +356,7 @@
     <div>
       <span class="added">ADDED: </span>Integration with Source Control! New notification area indicator if project and files are under source control.</div>
     <div>
-      <span class="note">NOTE: </span> *Will Checkout and Add files only*   You will still need to checkin/commit your changes manually</div>
+      <span class="note">NOTE: </span> *Will Checkout and Add files only*   You will still need to check-in/commit your changes manually</div>
     <div>
       <span class="updated">UPDATED: </span>Compiled against Version 11 of Server Management Objects (SMO) for compatibility with SQL 2012</div>
     <div>

--- a/src/SqlSync/change_notes.xml
+++ b/src/SqlSync/change_notes.xml
@@ -1,11 +1,17 @@
 <?xml-stylesheet type="text/xsl" href="change_notes.xslt"?>
 <SqlBuildManagerChangeNotes>
+  <Version Major="13" Minor="0" Revision="4">
+    <added>New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts</added>.
+    <added>New command `sbm list` to output script information of SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)</added>
+    <updated>The `sbm create` command can now also create an SBX project file, not just an SBM package</updated>
+    <updated>Tabular output for `sbm policycheck` command to make it easier to read. Defaulting enterprise config to GitHub file.</updated>
+  </Version>
   <Version Major="13" Minor="0" Revision="3">
     <fixed>Update to Dacpac change scripts to identify new header delimiter</fixed>
-    <fixed>Issue creating scripts between incompatable SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` </fixed>
+    <fixed>Issue creating scripts between incompatible SQL Server versions. Will now output a warning and continue to create the scripts with the flag `AllowIncompatiblePlatform=true` </fixed>
     <added>New command `sbm create` to create a new SBM file from a list of scripts</added>
-    <updated>Can now use Windows auth for DACPAC creation</updated>
-    <updated>updated Nuget packages</updated>
+    <updated>Can now use Windows authentication for DACPAC creation</updated>
+    <updated>updated NuGet packages</updated>
   </Version>
   <Version Major="13" Minor="0" Revision="2">
     <fixed>Update to ensure all Queue messages are retrieved efficiently</fixed>
@@ -30,7 +36,7 @@
         <note>**Removed old style command line (leveraging the `/Action=verb` flag etc.). Run `sbm --help` for instructions**</note>
         <note>Now built against .NET 5 and .NET Core 3.1</note>
         <added>New `threaded` and `batch` command options: `--concurrency` and `--concurrencytype`. See docs on [Concurrency Options](concurrency_options.md)</added>
-        <updated>Now leveraging `Microsoft.SqlServer.DACFx` Nuget package instead of `sqlpackage.exe` command line to manage DACPACs</updated>
+        <updated>Now leveraging `Microsoft.SqlServer.DACFx` NuGet package instead of `sqlpackage.exe` command line to manage DACPACs</updated>
         <!-- <updated>New version of sqlpackage.exe (18.7). Changed Windows version to .NET Core build</updated> -->
         <fixed>Updated `BlueSkyDev.Logging.AzureEventHubAppender` to v1.3.2 due to app hanging if EventHub connection string was incorrect</fixed>
     </Version>
@@ -64,7 +70,7 @@
     </Version>
     <Version Major="10" Minor="4" Revision="4">
         <added>Added command line argument `/DefaultScriptTimeout` (integer) to allow custom settings for the timeout of scripts when created from a DACPAC. Default is 500 seconds</added>
-        <updated>Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that reults in a build rollback</updated>
+        <updated>Refactored the `/TimeoutRetryCount` (integer) setting so it will be included in the `/SettingsFile`. This setting will retry build failures `X` times if the build fails because of any timeout error that results in a build rollback</updated>
     </Version>
     <Version Major="10" Minor="4" Revision="3">
         <added>New utility `/Action=SaveSettings` and `/SettingsFile` argument for simple reuse of settings.</added>
@@ -133,7 +139,7 @@
     </Version>
     <Version Major="10" Minor="1" Revision="1">
         <added>Added console argument /AzureRemoteStatus=true to list Azure remote execution machines and their readiness status</added>
-        <added>Added console argument /ForceCustomDacPac=true to force teh creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity</added>
+        <added>Added console argument /ForceCustomDacPac=true to force the creation of a custom dacpac and build script for each target database. USE WITH CAUTION this will exponentially increase the deployment time  and processing needs. Use only as a last scenario to ensure full database synchronicity</added>
         <fixed>Various remote/ threaded bug fixes</fixed>
     </Version>
     <Version Major="10" Minor="1" Revision="0">
@@ -156,7 +162,7 @@
     <Version Major="9" Minor="2" Revision="1">
         <!-- April 30, 2014 -->
         <added>New policy check status that warns you that code should be reviewed before release</added>
-        <added>command line abilty to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "&lt;Source Package Path and Name&gt;" </added>
+        <added>command line ability to check script policies. Usage: SqlBuildManager.Console.exe /PolicyCheck "&lt;Source Package Path and Name&gt;" </added>
         <added>command line ability to create a default backout package. Usage: `SqlBuildManager.Console.exe /CreateBackout "&lt;Source Package Path and Name&gt;" /server="&lt;Backout source server&gt;" /database="&lt;Backout source database&gt;`"</added>
         <fixed>Script policy icons were getting set to &quot;Policy checks not run&quot; after a committed build</fixed>
         <fixed>Database login error for accounts that do not have code review database permissions</fixed>
@@ -199,7 +205,7 @@
     <Version Major="8" Minor="8" Revision="0.1">
         <!-- July 10, 2012-->
         <added>Integration with Source Control! New notification area indicator if project and files are under source control.</added>
-        <note> *Will Checkout and Add files only*   You will still need to checkin/commit your changes manually</note>
+        <note> *Will Checkout and Add files only*   You will still need to check-in/commit your changes manually</note>
         <updated>Compiled against Version 11 of Server Management Objects (SMO) for compatibility with SQL 2012</updated>
         <updated>Improved threading when adding scripted files to ensure no dialog windows are "lost"</updated>
         <added>Will now accept WITH (READPAST) as valid query optimization. This should only be used in distinct use cases!</added>


### PR DESCRIPTION
ADDED: New command sbm add to add scripts to an existing SBM package or SBX project file from a list of scripts
ADDED: New command sbm list to output script information of SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)
UPDATED: The sbm create command can now also create an SBX project file, not just an SBM package
UPDATED: Tabular output for sbm policycheck command to make it easier to read. Defaulting enterprise config to GitHub file.