### PR TITLE
Version 13.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Example `SqlSyncBuildProject.xml` file. You can build this by hand to create you
 
 ### Forms UI
 
-While the focus of the app has changed to command line automation, the forms GUI is fully functional. If you are looking for a visual tool, check out _Sql Build Manager.exe_. There is documentation on the GUI that you can find [here](docs/SqlBuildManagerManual.md) that will walk through the creation of build packages ([PDF version](src/SqlBuildManager%20Manual/SqlBuildManagerManual.pdf)).
+While the focus of the app has changed to command line automation, the forms GUI is fully functional. If you are looking for a visual tool, check out _SqlBuildManager.exe_. There is documentation on the GUI that you can find [here](docs/SqlBuildManagerManual.md) that will walk through the creation of build packages ([PDF version](src/SqlBuildManager%20Manual/SqlBuildManagerManual.pdf)).
 
 ### Command line
 
@@ -86,15 +86,22 @@ There are several ways to create a build package from the command line.  Which y
 
 [Command line reference](docs/commandline.md)
 
-1. From a DACPAC file using the `sbm scriptextract` command. This method leverages a DACPAC that was created against your "Platinum Database" (why platinum? because it's even more precious than gold!). The Platinum database should have the schema that you want all of your other databases to look like. (don't have a DACPAC created, don't worry, you can create one with the `sbm dacpac` command) Learn more about DACPACs and [data-tier applications](https://docs.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-2017)  method.
+1. From a DACPAC file using the `sbm scriptextract` command. This method leverages a DACPAC that was created against your "Platinum Database" (why platinum? because it's even more precious than gold!). The Platinum database should have the schema that you want all of your other databases to look like. (don't have a DACPAC created, don't worry, you can create one with the `sbm dacpac` command) 
 
-2. From a set of script files using `sbm create`. This command allows you to specify an `--outputsbm` file to be created and a list of `--scripts` files to populate the SBM file with. 
+2. From various sources using `sbm create`. There are four sub-commands to help create an SBM package:
+
+   - `fromscripts` - Creates an SBM package or SBX project file from a list of scripts (type is determined by file extension: .sbm or .sbx)
+   - `fromdiff` - Creates an SBM package from a calculated diff between two databases (you provide the server and database names, and it connects them them and generates the diff scripts)
+   - `fromdacpacs` - Creates an SBM package from differences between two DACPAC files (use DACPACs you have created elsewhere or use `sbm dacpac` to create them)
+   - `fromdacpacdiff`- This method leverages a DACPAC that was created against your "Platinum Database" (why platinum? because it's even more precious than gold!). The Platinum database should have the schema that you want all of your other databases to look like.
+
+   Learn more about DACPACs and [data-tier applications](https://docs.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-2017)  method.
 
 3. From an SBX file. What is this? An SBX file is an XML file in the format of the `SqlSyncBuildProject.xml` file (see above) that has an `.sbx` extension. When you use the `sbm package` command, it will read the `.sbx` file and create the `.sbm` file with the referenced scripts.
-
 4. An SBM package file can be created indirectly as well, using the `sbm threaded run` and `sbm batch run` commands along with the `--platinumdbsource="<database name>"` and `--platinumserversource="<server name>"` the app will generate a DACPAC from the source database which will then be used to generate an SBM at run time to build directly on your target(s).
+5. You can also add new scripts to an existing SBM package or SBX project file using `sbm add`
 
-You can also add new scripts to an existing SBM package or SBX project file using `sbm add`
+_NOTE:_ The `sbm scriptextract` method is being deprecated in favor of `sbm create fromdacpacdiff` and will be removed in a future release
 
 ----
 

--- a/docs/azure_batch.md
+++ b/docs/azure_batch.md
@@ -125,35 +125,7 @@ sbm.exe batch run --settingsfile="C:\temp\my_settings.json" --settingsfilekey="C
 ----
 ## Log Details
 
-The logs will be stored in the Azure Storage account associated with the Batch account. You can view the logs in several ways, including the the [Azure portal](http://portal.azure.com), [Azure Batch Explorer](https://azure.github.io/BatchExplorer/) and [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/). However you view the logs, you will find a set of files and folders:
+For details on the log files that are created during a Batch run, see the [Log Details page](threaded_and_batch_logs.md). There is also a section on [troubleshooting tips](threaded_and_batch_logs.md#troubleshooting-tips)
 
-### Files
 
-_Note:_ All of these files are consolidated logs from across all of your Batch nodes.
-
-- `successdatabases.cfg` - this file contains a list of all databases that were successfully updated. The file is in the format used as an `--override` argument. If there were no successful updates, this file will not be created.
-- `failuredatabases.cfg` - this file contains a list of all databases that were successfully updated. The file is in the format used as an `--override` argument. If there were no failures, this file will not be created.
-- `commits.log` - a log file showing successful updates with time stamps
-- `errors.log` -  a log file showing failed updates with time stamps, statuses and return codes
-
-### Folders
-
-- `Task##` - There will be one folder for each worker node VM. The contents of this folder will be the standard output and standard error logs for the executable from that VM.
-- `Working` - this is the folder that contains the runtime files such as the DACPAC, SBM and distributed database configuration files
-- `<server name>` folders - There is one folder per target SQL Server. Within each of these is a folder for each target database. 
-  - `<database name>` folder - within these folders are three files
-    - `LogFile-\<date,time\>.log` -  a detailed script by script run result
-    - `SqlSyncBuildHistory.xml` - detailed log along with script meta-data (such as start/end times, file hash, status, user id)
-    - `SqlSyncBuildProject.xml` - meta-data file for the script package run against the database
-
-## Troubleshooting tips
-
-If you have SQL errors in your execution, you will probably want to figure out what happened. Here is a suggested troubleshooting path:
-
-1. Open up the `failuredatabases.cfg` file to see what databases had problems
-2. Taking note of the server and database name, open the server folder then the database folder
-3. Open the `logfile` in the database folder. This file should contain an error message that will guide your troubleshooting should you need to correct some scripts
-4. Once you have determined the problem, use the `failuredatabases.cfg` file as your `/Override` argument to run your updates again - hopefully successfully this time!
-
-----
 

--- a/docs/change_notes.md
+++ b/docs/change_notes.md
@@ -2,6 +2,13 @@
 # SQL Build Manager Change Notes
 
 
+### Version 13.1.0
+
+- *UPDATED:* The `sbm create` command now has four sub-commands `fromscripts`,  `fromdiff`, `fromdacpacs` and `fromdacpacdiff`. See the [Command Line Reference](commandline.md) for details and usage
+- **NOTE:** The `sbm scriptextract` command is being deprecated in favor of `sbm create fromdacpacdiff` and will be removed in a future release
+- *UPDATED:* Corrected how the `sbm build` local build command handles logging. It is now all encapsulated in the `.sbm` file as it should be
+- *UPDATED:* Documentation updates and improvements
+
 ### Version 13.0.4
 
 - *ADDED:* New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -16,6 +16,10 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 ### Utility actions
 
 - `create` - Creates an SBM package or SBX project file from a list of supplied script files
+  - `fromscripts` - Creates an SBM package or SBX project file from a list of scripts (type is determined by file extension: .sbm or .sbx)
+  - `fromdiff` - Creates an SBM package from a calculated diff between two databases
+  - `fromdacpacs` - Creates an SBM package from differences between two DACPAC files
+  - `fromdacpacdiff`- Extract a SBM package from a source `--platinumdacpac` and a target database connection
 - `add` - Adds scripts to an existing SBM package or SBX project file
 - `package` - Creates an SBM package from an SBX configuration file and scripts
 - `list` - Output scripts information on SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)
@@ -25,7 +29,7 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 - `createbackout` - Generates a back out package (reversing stored procedure and scripted object changes)
 - `getdifference` - Determines the difference between SQL Build run histories for two databases. Calculate and list out packages that need to be run between `--database` and `--golddatabase`. Only supports Windows Auth
 - `synchronize` - Performs a database synchronization between between `--database` and -`-golddatabase`. Can only be used for Windows Auth database targets
-- `scriptextract` - Extract a SBM package from a source `--platinumdacpac`
+- `scriptextract` - Extract a SBM package from a source `--platinumdacpac` (this command is being deprecated in favor of `sbm create fromdacpacdiff` and will be removed in a future release)
 
 
 ### Batch sub-commands (`sbm batch [command]`)
@@ -39,10 +43,10 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 #### For details information on running batch builds, see the Batch documentation
 
 - [`sbm batch savesettings`](azure_batch.md#settings-file)
-- [`sbm batch enqueue`](azure_batch.md#2.-queue-the-database-targets)
-- [`sbm batch run`](azure_batch.md#running-a-batch-build)
-- [`sbm batch prestage`](azure_batch.md#1.-pre-stage-the-azure-batch-pool-vms)
-- [`sbm batch cleanup`](azure_batch.md#5.-cleanup-post-build)
+- [`sbm batch enqueue`](azure_batch.md#2-queue-the-database-targets)
+- [`sbm batch run`](azure_batch.md#3-execute-batch-build)
+- [`sbm batch prestage`](azure_batch.md#1-pre-stage-the-azure-batch-pool-vms)
+- [`sbm batch cleanup`](azure_batch.md#5-cleanup-post-build)
 
 ----
 
@@ -50,47 +54,14 @@ The `sbm` executable uses a command pattern for execution `sbm [command]`
 
 For general logging, the
 SqlBuildManager.Console.exe has its own local messages. This log file is
-named SqlBuildManager.Console.log and can be found in the same folder as
+named SqlBuildManager.Console{date stamp}.log and can be found in the same folder as
 the executable. This file will be the first place to check for general
 execution errors or problems.
 
-To accommodate the logging of the actual build, all of the output is
+To accommodate the logging of a threaded or batch build, all of the output is
 saved to files and folders under the path specified in
 the `--rootloggingpath` flag. For a simple threaded execution, this is a
 single root folder. For a remote server execution, this folder is
 created for each execution server.
 
-### Working folder
-
-This folder is where the contents of the .SBM file are extracted. This
-file is extracted only once and loaded into memory for the duration of
-the run to efficiently use memory.
-
-### Commits.log
-
-Contains a list of all databases that the build was committed on. This
-is a quick reference for each location that had a successful execution.
-
-### Errors.log
-
-Contains a list of all databases that the build failed on and was rolled
-back. This is a quick reference for all locations that had failures.
-
-### Server/Database folders
-
-For each server/database combination that was executed, a folder
-structure is created for each server and a subfolder in those for each
-database. Inside each database level folder will be three files:
-
-- `LogFile-\<date,time\>.log`: This is the script execution log for the
-database. It contains the actual SQL scripts that were executed as well
-as the return results of the execution. This file is formatted as a SQL
-script itself and can be used manually if need-be.
-
-- `SqlSyncBuildHistory.xml`: the XML file showing run time meta-data
-details on each script file as executed including run time, file hash,
-run order and results.
-
-- `SqlSyncBuildProject.xml`: the XML file showing the design time
-meta-data on each script file that defined the run settings, script
-creation user ID's and the committed script record and hash for each.
+### For for details and script run troubleshooting suggestions, see [Log Files Details for Threaded and Batch execution](threaded_and_batch_logs.md)

--- a/docs/local_build.md
+++ b/docs/local_build.md
@@ -1,6 +1,6 @@
 # Local Builds
 
-If you have a single databases to update, you can use a local build.
+If you have a single database to update, you can use a local build.
 
 Sample command:
 
@@ -12,3 +12,12 @@ sbm build
     --server "targetserver" ^
     --database "targetdb" ^
 ```
+
+With a local build, the build history and log are stored within the `.sbm` file. You can get access to the logs either by opening up the Windows app `sqlbuildmanager.exe`'s Logging -> Show Build Logs menu or opening the `.sbm` file with a Zip file handler (7-zip, Windows zip handler, etc.) and see the `.log` files.
+
+FYI: an `.sbm` file is a zip file that contains:
+
+- All of the script files
+- The run metadata in the `SqlSyncBuildProject.xml` file
+- A build history summary in the `SqlSyncBuildHistory.xml` file (only included if there is a build history)
+- Detailed run logs in `LogFile-{date-time stamp}.log` files. These file contain the scripts and script output logs for each run and will contain detailed error messaging for any scripts that might have failed, so you can investigate and fix the scripts for a future run. These are also constructed as a run-able SQL scripts if you ever wanted to run them separately (only included if there are previous runs)

--- a/docs/override_options.md
+++ b/docs/override_options.md
@@ -1,8 +1,18 @@
 # Database targeting options
 
-In order for SQL Build Manager to do its job, you need to tell it what databases you want to update. This is done by sending it list in the form of an `--override` file. 
+- ### [Override File](#override-file)
+  - [File Format](#file-format)
+  - [Runtime](#runtime)
+- ### [Service Bus Topic](#service-bus-topic)
+  - [Background](#background)
+  - [Advantages](#advantages)
+  - [Queue Runtime](#queue-runtime)
+
+----
 
 ## Override file
+
+In order for SQL Build Manager to do its job, you need to tell it what databases you want to update. This is done by sending it list in the form of an `--override` file.
 
 ### File Format
 
@@ -28,6 +38,8 @@ Why `client`?  Inside the `.sbm` file, there is a default database target set to
 ### Runtime
 
 If the `--override` setting is provided but there isn't a `--servicebustopicconnection` value, the runtime will use this file directly to update the database and/or distribute traffic for `threaded` and `batch`. It is important to also understand the impact of [concurrency options](concurrency_options.md).
+
+----
 
 ## Service Bus Topic
 

--- a/docs/threaded_and_batch_logs.md
+++ b/docs/threaded_and_batch_logs.md
@@ -1,0 +1,117 @@
+# Log Files Details for Threaded and Batch execution
+
+Whether running a `threaded` or `batch` run, the tooling will create several log files for you reference, auditing and troubleshooting. 
+
+- For a `threaded run` these logs will be located in the current directory or in the path designated by the `--rootloggingpath` argument
+- For a `batch run` the logs will be stored in the Azure Storage account associated with the Batch account. You can view the logs in several ways, including the the [Azure portal](http://portal.azure.com), [Azure Batch Explorer](https://azure.github.io/BatchExplorer/) and [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/). 
+
+----
+
+## File Types
+- [Output Config Files](#output-config-files)
+- [High level log files](#high-level-log-files)
+- [Detailed Log Files](#detailed-log-files)
+- [Troubleshooting tips](#troubleshooting-tips)
+
+_Note:_ For a `batch run` these files are consolidated logs from across all of your Batch nodes and2 individually per node in the "Task#" subfolders 
+
+----
+
+## Output Config Files
+
+There will be one (or two, depending on the run success) .cfg files created - `successdatabases.cfg` and/or `failuredatabases.cfg`. These files contain lists of all databases that were either successfully updated or had a failure and were rolled back, respectively. The format is the same use in  an `--override` argument so it is easy to use this file a an override target source for any follow-up runs that may be necessary.
+
+Example contents for `successdatabases.cfg` and `failuredatabases.cfg`
+
+``` log
+sqllab2-b.database.windows.net:SqlBuildTest,SqlBuildTest001
+sqllab2-a.database.windows.net:SqlBuildTest,SqlBuildTest006
+sqllab2-b.database.windows.net:SqlBuildTest,SqlBuildTest006
+sqllab2-a.database.windows.net:SqlBuildTest,SqlBuildTest001
+sqllab2-b.database.windows.net:SqlBuildTest,SqlBuildTest007
+sqllab2-a.database.windows.net:SqlBuildTest,SqlBuildTest007
+sqllab2-a.database.windows.net:SqlBuildTest,SqlBuildTest002
+```
+
+----
+
+## High level log files
+
+For a quick reference, three high-level log files are created: `commits.log`,   `errors.log`, and `SqlBuildManager.ThreadedExecution.log`. The `commits.log` and `errors.log` files contain the top level success (commits) and failures (error) logs, including: time stamp, run id (a unique value for a single database build), server name, database name, and final return code for the database run (Committed, Rolled Back, etc.).
+
+_NOTE_The second column in each of the samples below is the unique "run id" for the build and can be correlated across all log files for a specific build run.
+
+Sample contents for `commits.log`
+
+``` log
+[2021-06-25 12:01:26.722 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest001: Committed
+[2021-06-25 12:01:26.722 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest006: Committed
+[2021-06-25 12:01:26.722 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest006: Committed
+[2021-06-25 12:01:26.722 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest001: Committed
+[2021-06-25 12:01:28.373 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest007: Committed
+[2021-06-25 12:01:28.397 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest007: Committed
+[2021-06-25 12:01:28.413 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest002: Committed
+[2021-06-25 12:01:28.432 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest002: Committed
+[2021-06-25 12:01:29.754 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest008: Committed
+```
+
+Sample contents for `errors.log`
+
+``` log
+[2021-06-25 11:48:57.944 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-a.database.windows.net  SqlBuildTest001: Rolled Back
+[2021-06-25 11:48:57.948 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-a.database.windows.net  SqlBuildTest009: Rolled Back
+[2021-06-25 11:48:57.952 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-a.database.windows.net  SqlBuildTest003: Rolled Back
+[2021-06-25 11:48:57.965 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-b.database.windows.net  SqlBuildTest001: Rolled Back
+[2021-06-25 11:48:58.007 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-a.database.windows.net  SqlBuildTest007: Rolled Back
+[2021-06-25 11:48:58.015 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-b.database.windows.net  SqlBuildTest005: Rolled Back
+[2021-06-25 11:48:58.022 ] fcf97151e8de4fcf939a43891f2b817b  sqllab2-b.database.windows.net  SqlBuildTest003: Rolled Back
+```
+
+The `SqlBuildManager.ThreadedExecution.log` file contains some additional detail specific to the concurrency and timing of each thread (Queuing up thread, Starting up thread, Thread complete) as well as some summary information on the duration and number of targets for a build.
+
+Sample contents for `SqlBuildManager.ThreadedExecution.log`
+
+``` log
+[2021-06-25 12:01:31.251 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest010: Starting up thread
+[2021-06-25 12:01:31.257 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest004: Thread complete
+[2021-06-25 12:01:31.257 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest005: Queuing up thread
+[2021-06-25 12:01:31.257 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest005: Starting up thread
+[2021-06-25 12:01:31.284 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest004: Thread complete
+[2021-06-25 12:01:31.284 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest005: Queuing up thread
+[2021-06-25 12:01:31.284 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest005: Starting up thread
+[2021-06-25 12:01:33.532 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest010: Thread complete
+[2021-06-25 12:01:33.535 ] f929636010584a68827634229c9f3b3e  sqllab2-a.database.windows.net  SqlBuildTest005: Thread complete
+[2021-06-25 12:01:33.541 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest010: Thread complete
+[2021-06-25 12:01:33.768 ] f929636010584a68827634229c9f3b3e  sqllab2-b.database.windows.net  SqlBuildTest005: Thread complete
+[2021-06-25 12:01:33.768 ] f929636010584a68827634229c9f3b3e    : Ending threaded processing at 6/25/2021 4:01:33 PM
+[2021-06-25 12:01:33.768 ] f929636010584a68827634229c9f3b3e    : Execution Duration: 00:00:09.6377429
+[2021-06-25 12:01:33.768 ] f929636010584a68827634229c9f3b3e    : Total number of targets: 20
+```
+
+----
+
+## Detailed Log Files
+
+### SqlBuildManager.Console{date stamp}.log
+
+This file contains the detailed console output. It is a capture of all of the logs that stream by in your command/console window during a build run.
+
+### "Working" folder
+
+This is the folder that contains the runtime files such as the DACPAC, SBM and distributed database configuration files. It will also contain a sub-folder for each database server target. The folder structure is:
+ - `<server name>` folders - There is one folder per target SQL Server. Within each of these is a folder for each target database. 
+    - `<database name>` folders - within these folders are three files
+      - `LogFile-\<date,time\>.log` -  a detailed script by script run result
+      - `SqlSyncBuildHistory.xml` - detailed log along with script meta-data (such as start/end times, file hash, status, user id)
+      - `SqlSyncBuildProject.xml` - meta-data file for the script package run against the database
+
+----
+
+## Troubleshooting tips
+
+If you have SQL errors in your execution, you will probably want to figure out what happened. Here is a suggested troubleshooting path:
+
+1. Open up the `failuredatabases.cfg` file to see what databases had problems
+2. Taking note of the server and database name, open the server folder then the database folder
+3. Open the `logfile` in the database folder. This file should contain an error message that will guide your troubleshooting should you need to correct some scripts
+4. Once you have determined the problem, use the `failuredatabases.cfg` file as your `--override` argument to run your updates again - hopefully successfully this time!

--- a/docs/threaded_build.md
+++ b/docs/threaded_build.md
@@ -1,6 +1,6 @@
 # Threaded Build Execution
 
-If you have a handful of databases, you can run them in parallel with a threaded build. You can control the concurrency of the tasks - refer to the [concurrency options](concurrency_options.md) for full details.
+If you have a handful of databases, you can run them in parallel with a threaded build (multiple update threads running from a single machine). You can control the concurrency of the tasks - refer to the [concurrency options](concurrency_options.md) for full details.
 
 To manage the database targets, you will need an override target file. The details of the contents of this file can be found [here](override_options.md)
 
@@ -13,3 +13,5 @@ sbm threaded run
     --password "dbpassword" ^
     --override "targetdatabases.cfg" ^
 ```
+
+When you execute an `sbm threaded run` build, in addition to the console output, it will create a number of log files. They will be created in the location of the `--rootloggingpath` setting or in the current directory if `--rootloggingpath` is not provided. For details on the log files and their contents, please see [Log Files Details for Threaded and Batch execution](threaded_and_batch_logs.md)

--- a/src/AssemblyVersioning.cs
+++ b/src/AssemblyVersioning.cs
@@ -25,7 +25,7 @@
 //   These can be found in SqlBuildManager.Setup -> Organize Your Setup -> General Information
 // ** Also, don't forget to update the change_notes.xml and .html files!
 
-[assembly: AssemblyVersion("13.0.4")]
-[assembly: AssemblyFileVersion("13.0.4")]
+[assembly: AssemblyVersion("13.1.0")]
+[assembly: AssemblyFileVersion("13.1.0")]
 
 

--- a/src/SqlBuildManager.Console/Threaded/ThreadedExecution.cs
+++ b/src/SqlBuildManager.Console/Threaded/ThreadedExecution.cs
@@ -570,7 +570,10 @@ namespace SqlBuildManager.Console.Threaded
         }
         private void InitThreadedLogging()
         {
-            logEventHub = SqlBuildManager.Logging.Threaded.EventHubLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, cmdLine.BatchArgs.EventHubConnectionString);
+            if (!string.IsNullOrWhiteSpace(cmdLine.BatchArgs.EventHubConnectionString))
+            {
+                logEventHub = SqlBuildManager.Logging.Threaded.EventHubLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, cmdLine.BatchArgs.EventHubConnectionString);
+            }
             logRuntime = SqlBuildManager.Logging.Threaded.RuntimeLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, cmdLine.RootLoggingPath);
 
             logFailures = SqlBuildManager.Logging.Threaded.FailureDatabaseLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, cmdLine.RootLoggingPath);

--- a/src/SqlBuildManager.Console/Validation.cs
+++ b/src/SqlBuildManager.Console/Validation.cs
@@ -307,7 +307,7 @@ namespace SqlBuildManager.Console
                 if (cmdLine.DacPacArgs.ForceCustomDacPac == false)
                 {
                     string sbmName;
-                    var stat = Program.GetSbmFromDacPac(cmdLine, multiDb, out sbmName);
+                    var stat = Program.GetSbmFromDacPac(cmdLine, multiDb, out sbmName, true);
                     if (stat == DacpacDeltasStatus.Success)
                     {
                         cmdLine.BuildFileName = sbmName;

--- a/src/SqlBuildManager.Console/sbm.csproj
+++ b/src/SqlBuildManager.Console/sbm.csproj
@@ -33,11 +33,12 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.AzureEventHub" Version="6.0.0-dev-00060" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
 	  <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+	  <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.DirectoryServices" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.Batch" Version="14.0.0" />

--- a/src/SqlBuildManager.Enterprise/EnterpriseConfigHelper.cs
+++ b/src/SqlBuildManager.Enterprise/EnterpriseConfigHelper.cs
@@ -83,7 +83,7 @@ namespace SqlBuildManager.Enterprise
                 System.Net.WebRequest req = System.Net.WebRequest.Create(configPath);
                 req.Proxy = System.Net.WebRequest.DefaultWebProxy;
                 req.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
-                req.Timeout = 2000;
+                req.Timeout = 6000;
                 System.Net.WebResponse resp = req.GetResponse();
                 System.IO.StreamReader sr = new System.IO.StreamReader(resp.GetResponseStream());
 

--- a/src/SqlBuildManager.Logging/SqlBuildManager.Logging.csproj
+++ b/src/SqlBuildManager.Logging/SqlBuildManager.Logging.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.2.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.AzureEventHub" Version="6.0.0-dev-00060" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
@@ -32,7 +32,7 @@
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <!--<PackageReference Include="Serilog.Sinks.AzureEventHub" Version="5.0.0" />-->
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlSync.SqlBuild/SqlBuildFileHelper.cs
+++ b/src/SqlSync.SqlBuild/SqlBuildFileHelper.cs
@@ -166,7 +166,7 @@ namespace SqlSync.SqlBuild
         }
         #endregion
 
-        public static string InferOverridesFromPackage(string sbmFileName)
+        public static string InferOverridesFromPackage(string sbmFileName, string suppliedDbName)
         {
             string tempWorkingDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             string projectFilePath = string.Empty;
@@ -185,7 +185,14 @@ namespace SqlSync.SqlBuild
                     {
                         foreach(var t in targets)
                         {
-                            ovr.Append($"{t},{t};");
+                            if (!string.IsNullOrWhiteSpace(suppliedDbName))
+                            {
+                                ovr.Append($"{t},{suppliedDbName};");
+                            }
+                            else
+                            {
+                                ovr.Append($"{t},{t};");
+                            }
                         }
                         ovr.Length = ovr.Length - 1;
                     }
@@ -378,7 +385,7 @@ namespace SqlSync.SqlBuild
                         ref buildData,
                         projFileName,
                         shortFileName,
-                        i + 1,
+                        i,
                         "",
                         true,
                         true,
@@ -392,6 +399,14 @@ namespace SqlSync.SqlBuild
 
                 }
                 SqlBuildFileHelper.SaveSqlBuildProjectFile(ref buildData, projFileName, buildFileName, includeHistoryAndLogs);
+
+                //Clean up project file (not needed, it is now in the package)
+                try
+                {
+                    File.Delete(projFileName);
+                }
+                catch { log.LogWarning($"Unable to clean up temporary project file '{projFileName}'. Please remove manually."); }
+
                 return true;
             }
             catch(Exception exe)

--- a/src/SqlSync/BuildHistory/LogFileHistoryForm.cs
+++ b/src/SqlSync/BuildHistory/LogFileHistoryForm.cs
@@ -129,7 +129,7 @@ namespace SqlSync.BuildHistory
             // 
             this.mnuOpenInNotePad.Name = "mnuOpenInNotePad";
             this.mnuOpenInNotePad.Size = new System.Drawing.Size(209, 22);
-            this.mnuOpenInNotePad.Text = "Open Log File in NotePad";
+            this.mnuOpenInNotePad.Text = "Open Log File";
             this.mnuOpenInNotePad.Click += new System.EventHandler(this.mnuOpenInNotePad_Click);
             // 
             // btnArchive
@@ -229,7 +229,7 @@ namespace SqlSync.BuildHistory
 			{
 				string fileName = this.lstLogFiles.SelectedItems[0].Text;
 				Process prc = new Process();
-				prc.StartInfo.FileName = "notepad.exe";
+				prc.StartInfo.FileName = "explorer";
 				prc.StartInfo.Arguments = Path.Combine(this.basePath, fileName);
 				prc.Start();
 			}

--- a/src/SqlSync/SQLSync.csproj
+++ b/src/SqlSync/SQLSync.csproj
@@ -356,10 +356,10 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.AzureEventHub" Version="6.0.0-dev-00060" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="xcopy &quot;$(ProjectDir)SqlBuild\Utility&quot; &quot;$(TargetDir)Utility\&quot; /K /D /H /Y&#xD;&#xA;xcopy &quot;$(ProjectDir)SqlBuild\Default Scripts&quot; &quot;$(TargetDir)Default Scripts\&quot; /K /D /H /Y" />

--- a/src/SqlSync/change_notes.html
+++ b/src/SqlSync/change_notes.html
@@ -39,6 +39,16 @@
   </head>
   <body>
     <h1>SQL Build Manager Change Notes</h1>
+    <div class="version">Version 13.1.0</div>
+    <div>
+      <span class="updated">UPDATED: </span>The `sbm create` command now has four sub-commands `fromscripts`,  `fromdiff`, `fromdacpacs` and `fromdacpacdiff`. See the [Command Line Reference](commandline.md) for details and usage</div>
+    <div>
+      <span class="note">NOTE: </span>The `sbm scriptextract` command is being deprecated in favor of `sbm create fromdacpacdiff` and will be removed in a future release</div>
+    <div>
+      <span class="updated">UPDATED: </span>Corrected how the `sbm build` local build command handles logging. It is now all encapsulated in the `.sbm` file as it should be</div>
+    <div>
+      <span class="updated">UPDATED: </span>Documentation updates and improvements</div>
+    <br />
     <div class="version">Version 13.0.4</div>
     <div>
       <span class="added">ADDED: </span>New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts</div>

--- a/src/SqlSync/change_notes.xml
+++ b/src/SqlSync/change_notes.xml
@@ -1,5 +1,11 @@
 <?xml-stylesheet type="text/xsl" href="change_notes.xslt"?>
 <SqlBuildManagerChangeNotes>
+	<Version Major="13" Minor="1" Revision="0">
+		<updated>The `sbm create` command now has four sub-commands `fromscripts`,  `fromdiff`, `fromdacpacs` and `fromdacpacdiff`. See the [Command Line Reference](commandline.md) for details and usage</updated>
+		<note>The `sbm scriptextract` command is being deprecated in favor of `sbm create fromdacpacdiff` and will be removed in a future release</note>
+		<updated>Corrected how the `sbm build` local build command handles logging. It is now all encapsulated in the `.sbm` file as it should be</updated>
+	    <updated>Documentation updates and improvements</updated>
+	</Version>
   <Version Major="13" Minor="0" Revision="4">
     <added>New command `sbm add` to add scripts to an existing SBM package or SBX project file from a list of scripts</added>.
     <added>New command `sbm list` to output script information of SBM packages (run order, script name, date added/modified, user info, script ids, script hashes)</added>


### PR DESCRIPTION
UPDATED: The sbm create command now has four sub-commands fromscripts, fromdiff, fromdacpacs and fromdacpacdiff. See the Command Line Reference for details and usage
NOTE: The sbm scriptextract command is being deprecated in favor of sbm create fromdacpacdiff and will be removed in a future release
UPDATED: Corrected how the sbm build local build command handles logging. It is now all encapsulated in the .sbm file as it should be
UPDATED: Documentation updates and improvements