### PR TITLE
Fixing GitHub Actions Container build

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -3,7 +3,7 @@ name: container_build
 on:
   push:
     branches:
-      - master
+      - '*'
 
   pull_request:
     branches:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:src"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           provenance: false
           tags: |

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:src"
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           provenance: false
           tags: |

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -18,16 +18,16 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -30,15 +30,14 @@ COPY ["SqlSync.SqlBuild/SqlSync.SqlBuild.csproj", "SqlSync.SqlBuild/SqlSync.SqlB
 RUN true 
 COPY ["SqlBuildManager.ScriptHandling/SqlBuildManager.ScriptHandling.csproj", "SqlBuildManager.ScriptHandling/"]
 
-#RUN true 
-#RUN dotnet restore "SqlBuildManager.Console/sbm.csproj"
-
 
 COPY . .
 WORKDIR "/src/SqlBuildManager.Console"
-#RUN dotnet build "sbm.csproj" --configuration Release -f net8.0 -o /app/build -r linux-x64 --self-contained
 
-FROM build AS publish
+
+FROM build AS publish   
+RUN dotnet clean 
+RUN dotnet nuget locals all --clear
 RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux-x64  --self-contained
 
 FROM base AS final

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,9 +10,9 @@ WORKDIR "/SqlBuildManager.Console"
 
 
 FROM build AS publish   
-RUN dotnet clean --configuration Release -f net8.0 -r linux-x64
+RUN dotnet clean --configuration Release -f net8.0 
 RUN dotnet nuget locals all --clear
-RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux-x64  --self-contained
+RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish   --self-contained
 
 FROM base AS final
 WORKDIR /app

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR "/SqlBuildManager.Console"
 FROM build AS publish   
 RUN dotnet clean --configuration Release -f net8.0 
 RUN dotnet nuget locals all --clear
-RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish   --self-contained
+RUN dotnet publish sbm.csproj --configuration Release -f net8.0 -o /app/publish   --self-contained
 
 FROM base AS final
 WORKDIR /app

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,39 +4,13 @@ FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-WORKDIR /src
-
-
-#The goofy "RUN true" is added because of bug: https://github.com/moby/moby/issues/37965 . Can be removed once this is fixed
-COPY ["SqlBuildManager.Console/sbm.csproj", "SqlBuildManager.Console/"]
-RUN true 
-COPY ["SqlBuildManager.Enterprise/SqlBuildManager.Enterprise.csproj", "SqlBuildManager.Enterprise/" ]
-RUN true 
-COPY ["SqlBuildManager.Interfaces/SqlBuildManager.Interfaces.csproj", "SqlBuildManager.Interfaces/" ]
-RUN true 
-COPY ["SqlBuildManager.Logging/SqlBuildManager.Logging.csproj", "SqlBuildManager.Logging/" ]
-RUN true 
-COPY ["SqlSync.Connection/SqlSync.Connection.csproj", "SqlSync.Connection/" ]
-RUN true 
-COPY ["SqlSync.Constants/SqlSync.Constants.csproj", "SqlSync.Constants/" ]
-RUN true 
-COPY ["SqlSync.DbInformation/SqlSync.DbInformation.csproj", "SqlSync.DbInformation/" ]
-RUN true 
-COPY ["SqlSync.ObjectScript/SqlSync.ObjectScript.csproj", "SqlSync.ObjectScript/" ]
-RUN true 
-COPY ["SqlSync.SqlBuild/SqlSync.SqlBuild.csproj", "SqlSync.SqlBuild/" ]
-RUN true 
-COPY ["SqlSync.SqlBuild/SqlSync.SqlBuild.csproj", "SqlSync.SqlBuild/SqlSync.SqlBuild.csproj" ]
-RUN true 
-COPY ["SqlBuildManager.ScriptHandling/SqlBuildManager.ScriptHandling.csproj", "SqlBuildManager.ScriptHandling/"]
-
 
 COPY . .
-WORKDIR "/src/SqlBuildManager.Console"
+WORKDIR "/SqlBuildManager.Console"
 
 
 FROM build AS publish   
-RUN dotnet clean 
+RUN dotnet clean --configuration Release -f net8.0 -r linux-x64
 RUN dotnet nuget locals all --clear
 RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux-x64  --self-contained
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR "/src/SqlBuildManager.Console"
 FROM build AS publish   
 RUN dotnet clean 
 RUN dotnet nuget locals all --clear
-RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux  --self-contained
+RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux-x64  --self-contained
 
 FROM base AS final
 WORKDIR /app

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR "/src/SqlBuildManager.Console"
 FROM build AS publish   
 RUN dotnet clean 
 RUN dotnet nuget locals all --clear
-RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux-x64  --self-contained
+RUN dotnet publish "sbm.csproj" --configuration Release -f net8.0 -o /app/publish -r linux  --self-contained
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and the Dockerfile. The changes in the workflow include modification to the triggering branches, updating the versions of the actions used, and changing the build platforms. In the Dockerfile, the changes involve cleaning up the build process and removing unnecessary commands.

GitHub Actions workflow changes:

* [`.github/workflows/container-build.yml`](diffhunk://#diff-2a66da73436042ba8bf55a760599d9d73b22be874b1d13e02f3f2839263b87a8L6-R6): The workflow is now triggered on push to any branch instead of just the master branch.
* [`.github/workflows/container-build.yml`](diffhunk://#diff-2a66da73436042ba8bf55a760599d9d73b22be874b1d13e02f3f2839263b87a8L21-R30): The versions of the actions used, including `actions/checkout`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `docker/login-action`, have been updated.
* [`.github/workflows/container-build.yml`](diffhunk://#diff-2a66da73436042ba8bf55a760599d9d73b22be874b1d13e02f3f2839263b87a8L40-R40): The build platforms have been changed to only `linux/amd64`.

Dockerfile changes:

* [`src/Dockerfile`](diffhunk://#diff-f7c91877446336ef59ebfaacb472e50e4e40bbe54938f232b0fd54617eb6e7dcL7-R15): The build process has been cleaned up by removing unnecessary `RUN true` and `COPY` commands, changing the working directory, and adding commands to clean the build and clear NuGet locals before publishing.