### PR TITLE
Honor username and password Sql Auth parameters

### DIFF
--- a/src/SqlBuildManager.Console/CommandLine/Extensions.cs
+++ b/src/SqlBuildManager.Console/CommandLine/Extensions.cs
@@ -91,7 +91,7 @@ namespace SqlBuildManager.Console.CommandLine
                      {
                         args.AddRange(new string[] { "--authtype", "Password".Quoted() });
                         
-                        // Pass username and password parameters when using Password authentication
+                        // Honor passed username and password parameters when using Password authentication
                         if (!string.IsNullOrWhiteSpace(cmd.AuthenticationArgs.UserName))
                         {
                            args.AddRange(new string[] { "--username", cmd.AuthenticationArgs.UserName.Quoted() });

--- a/src/SqlBuildManager.Console/CommandLine/Extensions.cs
+++ b/src/SqlBuildManager.Console/CommandLine/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using Azure.ResourceManager.Resources.Models;
+using Azure.ResourceManager.Resources.Models;
 using Microsoft.SqlServer.Management.Dmf;
 using SqlBuildManager.Console.ContainerApp.Internal;
 using System;
@@ -86,6 +86,20 @@ namespace SqlBuildManager.Console.CommandLine
                      if (cmd.AuthenticationArgs.AuthenticationType == SqlSync.Connection.AuthenticationType.ManagedIdentity)
                      {
                         args.AddRange(new string[] { "--authtype", "ManagedIdentity".Quoted() });
+                     }
+                     else if (cmd.AuthenticationArgs.AuthenticationType == SqlSync.Connection.AuthenticationType.Password)
+                     {
+                        args.AddRange(new string[] { "--authtype", "Password".Quoted() });
+                        
+                        // Pass username and password parameters when using Password authentication
+                        if (!string.IsNullOrWhiteSpace(cmd.AuthenticationArgs.UserName))
+                        {
+                           args.AddRange(new string[] { "--username", cmd.AuthenticationArgs.UserName.Quoted() });
+                        }
+                        if (!string.IsNullOrWhiteSpace(cmd.AuthenticationArgs.Password))
+                        {
+                           args.AddRange(new string[] { "--password", cmd.AuthenticationArgs.Password.Quoted() });
+                        }
                      }
                   }
 


### PR DESCRIPTION
Our configuration that was using a key vault was expecting secrets named Username and Password. Supplying these works correctly, however we have a setup that requires different credentials using the same Azure batch infrastructure, and found that it wasn't honoring CLI-fed --username and --password parameters.  This change address this - otherwise not having them in the keyvault results in empty strings passed to the connection string (i.e. failed connections)