### PR TITLE
azd up fix for postgres and improved CLI help output

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -162,6 +162,9 @@ module containerAppEnv './modules/containerappenv.bicep' = if(deployContainerApp
 module databases './modules/database.bicep' = if(deploySqlServer && testDbCountPerServer > 0 && userIdGuid != '' && userLoginName != ''){
   name: 'databases'
   scope: rg
+  dependsOn: [
+    identityResource
+  ]
   params: { 
     currentIpAddress: currentIpAddress
     location: location

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.39.26.7824",
-      "templateHash": "13997598022504672822"
+      "version": "0.41.2.15936",
+      "templateHash": "16903517472333661973"
     }
   },
   "parameters": {
@@ -72,6 +72,13 @@
         "description": "Whether to deploy AKS"
       }
     },
+    "deploySqlServer": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether to deploy SQL Server databases"
+      }
+    },
     "testDbCountPerServer": {
       "type": "int",
       "defaultValue": 10,
@@ -84,6 +91,20 @@
       "defaultValue": false,
       "metadata": {
         "description": "Whether to use private endpoints for SQL Server connectivity instead of public network access"
+      }
+    },
+    "deployPostgreSQL": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether to deploy Azure Database for PostgreSQL Flexible Server"
+      }
+    },
+    "pgAdminPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Administrator password for PostgreSQL Flexible Server"
       }
     },
     "eventhubSku": {
@@ -193,8 +214,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "9139758266500504447"
+              "version": "0.41.2.15936",
+              "templateHash": "2224254650562741268"
             }
           },
           "parameters": {
@@ -591,8 +612,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "9581136584625360812"
+              "version": "0.41.2.15936",
+              "templateHash": "16847190691054535560"
             }
           },
           "parameters": {
@@ -692,6 +713,45 @@
               "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
               ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(parameters('resourceGroupName'), 'kubernetesClusterAdmin', parameters('identityName'))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(parameters('resourceGroupName'), 'kubernetesRbacAdmin', parameters('identityName'))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '3498e952-d568-435e-9b2c-8d77e338d7f7')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(parameters('resourceGroupName'), 'kubernetesServiceAdmin', parameters('identityName'))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -744,8 +804,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "10230576418256444235"
+              "version": "0.41.2.15936",
+              "templateHash": "6489548732844840811"
             }
           },
           "parameters": {
@@ -880,8 +940,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "10964669659935231485"
+              "version": "0.41.2.15936",
+              "templateHash": "16138724210690245444"
             }
           },
           "parameters": {
@@ -962,8 +1022,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "1368607086433929292"
+              "version": "0.41.2.15936",
+              "templateHash": "3097809086701671639"
             }
           },
           "parameters": {
@@ -1053,7 +1113,7 @@
       ]
     },
     {
-      "condition": "[and(and(greater(parameters('testDbCountPerServer'), 0), not(equals(parameters('userIdGuid'), ''))), not(equals(parameters('userLoginName'), '')))]",
+      "condition": "[and(and(and(parameters('deploySqlServer'), greater(parameters('testDbCountPerServer'), 0)), not(equals(parameters('userIdGuid'), ''))), not(equals(parameters('userLoginName'), '')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
       "name": "databases",
@@ -1101,8 +1161,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "17864223431006277455"
+              "version": "0.41.2.15936",
+              "templateHash": "17090119488604772271"
             }
           },
           "parameters": {
@@ -1174,10 +1234,10 @@
             }
           },
           "variables": {
-            "resourceGroupNameVar": "[format('{0}-rg', parameters('namePrefix'))]",
             "sqlserverNameVar": "[format('{0}sql', parameters('namePrefix'))]",
             "sqlpoolNameVar": "[format('{0}pool', parameters('namePrefix'))]",
             "identityNameVar": "[format('{0}identity', parameters('namePrefix'))]",
+            "vnetNameVar": "[format('{0}vnet', parameters('namePrefix'))]",
             "subnetNamesArray": "[split(parameters('subnetNames'), ',')]",
             "sqlPrivateDnsZoneName": "[format('privatelink{0}', environment().suffixes.sqlServerHostname)]"
           },
@@ -1224,10 +1284,9 @@
               "name": "[format('{0}/{1}', format('{0}-a', variables('sqlserverNameVar')), format('{0}A_{1}', variables('sqlserverNameVar'), variables('subnetNamesArray')[copyIndex()]))]",
               "properties": {
                 "ignoreMissingVnetServiceEndpoint": false,
-                "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupNameVar')), 'Microsoft.Resources/deployments', 'networkResource'), '2025-04-01').outputs.vnetName.value, variables('subnetNamesArray')[copyIndex()])]"
+                "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetNameVar'), variables('subnetNamesArray')[copyIndex()])]"
               },
               "dependsOn": [
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupNameVar')), 'Microsoft.Resources/deployments', 'networkResource')]",
                 "[resourceId('Microsoft.Sql/servers', format('{0}-a', variables('sqlserverNameVar')))]"
               ]
             },
@@ -1324,10 +1383,9 @@
               "name": "[format('{0}/{1}', format('{0}-b', variables('sqlserverNameVar')), format('{0}B_{1}', variables('sqlserverNameVar'), variables('subnetNamesArray')[copyIndex()]))]",
               "properties": {
                 "ignoreMissingVnetServiceEndpoint": false,
-                "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupNameVar')), 'Microsoft.Resources/deployments', 'networkResource'), '2025-04-01').outputs.vnetName.value, variables('subnetNamesArray')[copyIndex()])]"
+                "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetNameVar'), variables('subnetNamesArray')[copyIndex()])]"
               },
               "dependsOn": [
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupNameVar')), 'Microsoft.Resources/deployments', 'networkResource')]",
                 "[resourceId('Microsoft.Sql/servers', format('{0}-b', variables('sqlserverNameVar')))]"
               ]
             },
@@ -1496,12 +1554,460 @@
                 "[resourceId('Microsoft.Network/privateDnsZones', variables('sqlPrivateDnsZoneName'))]",
                 "[resourceId('Microsoft.Network/privateEndpoints', format('{0}sql-b-pe', parameters('namePrefix')))]"
               ]
+            }
+          ],
+          "outputs": {
+            "identityName": {
+              "type": "string",
+              "value": "[variables('identityNameVar')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'identityResource')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'networkResource')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+      ]
+    },
+    {
+      "condition": "[and(and(and(parameters('deployPostgreSQL'), not(equals(parameters('userIdGuid'), ''))), not(equals(parameters('userLoginName'), ''))), not(equals(parameters('pgAdminPassword'), '')))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "postgresql",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "namePrefix": {
+            "value": "[parameters('namePrefix')]"
+          },
+          "testDbCountPerServer": {
+            "value": "[parameters('testDbCountPerServer')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "currentIpAddress": {
+            "value": "[parameters('currentIpAddress')]"
+          },
+          "subnetNames": {
+            "value": "[join(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'networkResource'), '2025-04-01').outputs.subnetNames.value, ',')]"
+          },
+          "pgAdminObjectId": {
+            "value": "[parameters('userIdGuid')]"
+          },
+          "pgAdminLogin": {
+            "value": "[parameters('userLoginName')]"
+          },
+          "pgAdminPassword": {
+            "value": "[parameters('pgAdminPassword')]"
+          },
+          "usePrivateEndpoint": {
+            "value": "[parameters('usePrivateEndpoint')]"
+          },
+          "vnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'networkResource'), '2025-04-01').outputs.vnetId.value]"
+          },
+          "privateEndpointSubnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'networkResource'), '2025-04-01').outputs.privateEndpointSubnetId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.41.2.15936",
+              "templateHash": "10740458311415523395"
+            }
+          },
+          "parameters": {
+            "namePrefix": {
+              "type": "string",
+              "metadata": {
+                "description": "Prefix to prepend to account names"
+              }
+            },
+            "testDbCountPerServer": {
+              "type": "int",
+              "defaultValue": 10,
+              "metadata": {
+                "description": "Number of test databases to create per server"
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Location for all resources."
+              }
+            },
+            "currentIpAddress": {
+              "type": "string",
+              "metadata": {
+                "description": "Current machine IP address to allow access to the PostgreSQL server."
+              }
+            },
+            "subnetNames": {
+              "type": "string",
+              "metadata": {
+                "description": "Array of subnet resource ids to allow access via VNet rules."
+              }
+            },
+            "pgAdminObjectId": {
+              "type": "string",
+              "metadata": {
+                "description": "Object ID (GUID) of the Entra ID user or group to set as PG AAD admin"
+              }
+            },
+            "pgAdminLogin": {
+              "type": "string",
+              "metadata": {
+                "description": "Login name (email) of the Entra ID admin"
+              }
+            },
+            "pgAdminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Administrator password for PostgreSQL (used for local/password-based auth)"
+              }
+            },
+            "usePrivateEndpoint": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Whether to use private endpoints instead of public network access"
+              }
+            },
+            "vnetId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "VNet ID for private DNS zone link (required when usePrivateEndpoint is true)"
+              }
+            },
+            "privateEndpointSubnetId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Private endpoint subnet ID (required when usePrivateEndpoint is true)"
+              }
+            }
+          },
+          "variables": {
+            "pgServerNameA": "[format('{0}pgserver-a', parameters('namePrefix'))]",
+            "pgServerNameB": "[format('{0}pgserver-b', parameters('namePrefix'))]",
+            "pgAdminUser": "[format('{0}pgadmin', parameters('namePrefix'))]",
+            "subnetNamesArray": "[split(parameters('subnetNames'), ',')]",
+            "pgPrivateDnsZoneName": "privatelink.postgres.database.azure.com"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+              "apiVersion": "2024-08-01",
+              "name": "[variables('pgServerNameA')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_B1ms",
+                "tier": "Burstable"
+              },
+              "properties": {
+                "version": "16",
+                "administratorLogin": "[variables('pgAdminUser')]",
+                "administratorLoginPassword": "[parameters('pgAdminPassword')]",
+                "storage": {
+                  "storageSizeGB": 32,
+                  "autoGrow": "Disabled"
+                },
+                "backup": {
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "highAvailability": {
+                  "mode": "Disabled"
+                },
+                "authConfig": {
+                  "activeDirectoryAuth": "Enabled",
+                  "passwordAuth": "Enabled",
+                  "tenantId": "[subscription().tenantId]"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/administrators",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameA'), parameters('pgAdminObjectId'))]",
+              "properties": {
+                "principalType": "User",
+                "principalName": "[parameters('pgAdminLogin')]",
+                "tenantId": "[subscription().tenantId]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameA'), 'AllowAzureServices')]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameA'), format('{0}_AllowCurrentIpA', parameters('namePrefix')))]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]"
+              ]
+            },
+            {
+              "condition": "[not(equals(parameters('currentIpAddress'), ''))]",
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameA'), format('{0}_AllowCurrentIpA', parameters('namePrefix')))]",
+              "properties": {
+                "startIpAddress": "[parameters('currentIpAddress')]",
+                "endIpAddress": "[parameters('currentIpAddress')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameA'), 'AllowAzureServices')]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameA'), 'AllowAzureServices')]",
+              "properties": {
+                "startIpAddress": "0.0.0.0",
+                "endIpAddress": "0.0.0.0"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]"
+              ]
+            },
+            {
+              "copy": {
+                "name": "pgDatabasesA",
+                "count": "[length(range(1, parameters('testDbCountPerServer')))]",
+                "mode": "serial",
+                "batchSize": 1
+              },
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/databases",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameA'), format('sbm_pg_test{0}', range(1, parameters('testDbCountPerServer'))[copyIndex()]))]",
+              "properties": {
+                "charset": "UTF8",
+                "collation": "en_US.utf8"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/administrators', variables('pgServerNameA'), parameters('pgAdminObjectId'))]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+              "apiVersion": "2024-08-01",
+              "name": "[variables('pgServerNameB')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_B1ms",
+                "tier": "Burstable"
+              },
+              "properties": {
+                "version": "16",
+                "administratorLogin": "[variables('pgAdminUser')]",
+                "administratorLoginPassword": "[parameters('pgAdminPassword')]",
+                "storage": {
+                  "storageSizeGB": 32,
+                  "autoGrow": "Disabled"
+                },
+                "backup": {
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "highAvailability": {
+                  "mode": "Disabled"
+                },
+                "authConfig": {
+                  "activeDirectoryAuth": "Enabled",
+                  "passwordAuth": "Enabled",
+                  "tenantId": "[subscription().tenantId]"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/administrators",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameB'), parameters('pgAdminObjectId'))]",
+              "properties": {
+                "principalType": "User",
+                "principalName": "[parameters('pgAdminLogin')]",
+                "tenantId": "[subscription().tenantId]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameB'), 'AllowAzureServices')]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameB'), format('{0}_AllowCurrentIpB', parameters('namePrefix')))]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]"
+              ]
+            },
+            {
+              "condition": "[not(equals(parameters('currentIpAddress'), ''))]",
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameB'), format('{0}_AllowCurrentIpB', parameters('namePrefix')))]",
+              "properties": {
+                "startIpAddress": "[parameters('currentIpAddress')]",
+                "endIpAddress": "[parameters('currentIpAddress')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', variables('pgServerNameB'), 'AllowAzureServices')]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameB'), 'AllowAzureServices')]",
+              "properties": {
+                "startIpAddress": "0.0.0.0",
+                "endIpAddress": "0.0.0.0"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]"
+              ]
+            },
+            {
+              "copy": {
+                "name": "pgDatabasesB",
+                "count": "[length(range(1, parameters('testDbCountPerServer')))]",
+                "mode": "serial",
+                "batchSize": 1
+              },
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/databases",
+              "apiVersion": "2024-08-01",
+              "name": "[format('{0}/{1}', variables('pgServerNameB'), format('sbm_pg_test{0}', range(1, parameters('testDbCountPerServer'))[copyIndex()]))]",
+              "properties": {
+                "charset": "UTF8",
+                "collation": "en_US.utf8"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/administrators', variables('pgServerNameB'), parameters('pgAdminObjectId'))]",
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "[variables('pgPrivateDnsZoneName')]",
+              "location": "global"
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', variables('pgPrivateDnsZoneName'), format('{0}-pg-vnet-link', parameters('namePrefix')))]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                  "id": "[parameters('vnetId')]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('pgPrivateDnsZoneName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}pg-a-pe', parameters('namePrefix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[parameters('privateEndpointSubnetId')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "[format('{0}pg-a-plsc', parameters('namePrefix'))]",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]",
+                      "groupIds": [
+                        "postgresqlServer"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}', format('{0}pg-a-pe', parameters('namePrefix')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "privatelink-postgres-database-azure-com",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('pgPrivateDnsZoneName'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('pgPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('{0}pg-a-pe', parameters('namePrefix')))]"
+              ]
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}pg-b-pe', parameters('namePrefix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[parameters('privateEndpointSubnetId')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "[format('{0}pg-b-plsc', parameters('namePrefix'))]",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]",
+                      "groupIds": [
+                        "postgresqlServer"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('usePrivateEndpoint')]",
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}', format('{0}pg-b-pe', parameters('namePrefix')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "privatelink-postgres-database-azure-com",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('pgPrivateDnsZoneName'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('pgPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('{0}pg-b-pe', parameters('namePrefix')))]"
+              ]
             },
             {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2025-04-01",
-              "name": "networkResource",
-              "resourceGroup": "[variables('resourceGroupNameVar')]",
+              "name": "pgNetworkResource",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -1521,8 +2027,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.39.26.7824",
-                      "templateHash": "9139758266500504447"
+                      "version": "0.41.2.15936",
+                      "templateHash": "2224254650562741268"
                     }
                   },
                   "parameters": {
@@ -1891,164 +2397,32 @@
                   }
                 }
               }
-            },
-            {
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2025-04-01",
-              "name": "identityResource",
-              "resourceGroup": "[variables('resourceGroupNameVar')]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "identityName": {
-                    "value": "[variables('identityNameVar')]"
-                  },
-                  "location": {
-                    "value": "[parameters('location')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.39.26.7824",
-                      "templateHash": "9581136584625360812"
-                    }
-                  },
-                  "parameters": {
-                    "identityName": {
-                      "type": "string"
-                    },
-                    "location": {
-                      "type": "string",
-                      "defaultValue": "[resourceGroup().location]"
-                    },
-                    "resourceGroupName": {
-                      "type": "string",
-                      "defaultValue": "[resourceGroup().name]"
-                    }
-                  },
-                  "resources": [
-                    {
-                      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-                      "apiVersion": "2023-01-31",
-                      "name": "[parameters('identityName')]",
-                      "location": "[parameters('location')]"
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'storageBlobDataContributor', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'ServiceBusDataOwner', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'EventHubsDataReceiver', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'EventHubsDataSender', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '2b629674-e913-4c01-ae53-ef4638d8f975')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'AcrPull', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2020-04-01-preview",
-                      "name": "[guid(parameters('resourceGroupName'), 'Contributor', parameters('identityName'))]",
-                      "properties": {
-                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]",
-                        "principalType": "ServicePrincipal"
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "clientId": {
-                      "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').clientId]"
-                    },
-                    "tenantId": {
-                      "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').tenantId]"
-                    },
-                    "principalId": {
-                      "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')), '2023-01-31').principalId]"
-                    },
-                    "name": {
-                      "type": "string",
-                      "value": "[parameters('identityName')]"
-                    },
-                    "id": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-                    }
-                  }
-                }
-              }
             }
           ],
           "outputs": {
-            "identityName": {
+            "pgServerNameA": {
               "type": "string",
-              "value": "[variables('identityNameVar')]"
+              "value": "[variables('pgServerNameA')]"
+            },
+            "pgServerFqdnA": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameA')), '2024-08-01').fullyQualifiedDomainName]"
+            },
+            "pgServerNameB": {
+              "type": "string",
+              "value": "[variables('pgServerNameB')]"
+            },
+            "pgServerFqdnB": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('pgServerNameB')), '2024-08-01').fullyQualifiedDomainName]"
+            },
+            "pgAdminUser": {
+              "type": "string",
+              "value": "[variables('pgAdminUser')]"
+            },
+            "pgDatabaseCountPerServer": {
+              "type": "int",
+              "value": "[parameters('testDbCountPerServer')]"
             }
           }
         }
@@ -2092,8 +2466,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "3294596986679570136"
+              "version": "0.41.2.15936",
+              "templateHash": "4188474950963573327"
             }
           },
           "parameters": {
@@ -2220,8 +2594,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "2354031357425139855"
+              "version": "0.41.2.15936",
+              "templateHash": "17277977249020294607"
             }
           },
           "parameters": {
@@ -2429,8 +2803,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "10883610697897859022"
+              "version": "0.41.2.15936",
+              "templateHash": "16928681150804771891"
             }
           },
           "parameters": {
@@ -2546,6 +2920,25 @@
                 },
                 "accessTier": "Hot"
               }
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices",
+              "apiVersion": "2023-01-01",
+              "name": "[format('{0}/{1}', parameters('storageAccountName'), 'default')]",
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+              "apiVersion": "2023-01-01",
+              "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', 'testresults')]",
+              "properties": {
+                "publicAccess": "None"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccountName'), 'default')]"
+              ]
             },
             {
               "condition": "[parameters('usePrivateEndpoint')]",
@@ -2727,8 +3120,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "17078450746681495508"
+              "version": "0.41.2.15936",
+              "templateHash": "17268673842830550628"
             }
           },
           "parameters": {
@@ -2834,8 +3227,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "9258375249646276319"
+              "version": "0.41.2.15936",
+              "templateHash": "13083824312320113333"
             }
           },
           "parameters": {
@@ -3135,8 +3528,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "11812872965367337640"
+              "version": "0.41.2.15936",
+              "templateHash": "1133093448843533247"
             }
           },
           "parameters": {
@@ -3406,6 +3799,10 @@
       "type": "bool",
       "value": "[parameters('deployAks')]"
     },
+    "DEPLOY_SQLSERVER": {
+      "type": "bool",
+      "value": "[parameters('deploySqlServer')]"
+    },
     "TEST_DB_COUNT_PER_SERVER": {
       "type": "int",
       "value": "[parameters('testDbCountPerServer')]"
@@ -3425,6 +3822,10 @@
     "USE_PRIVATE_ENDPOINT": {
       "type": "bool",
       "value": "[parameters('usePrivateEndpoint')]"
+    },
+    "DEPLOY_POSTGRESQL": {
+      "type": "bool",
+      "value": "[parameters('deployPostgreSQL')]"
     },
     "RESOURCE_GROUP_NAME": {
       "type": "string",
@@ -3565,6 +3966,30 @@
     "AKS_SERVICE_ACCOUNT_NAME": {
       "type": "string",
       "value": "[if(parameters('deployAks'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'aks'), '2025-04-01').outputs.serviceAccountName.value, '')]"
+    },
+    "PG_SERVER_NAME_A": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgServerNameA.value, '')]"
+    },
+    "PG_SERVER_FQDN_A": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgServerFqdnA.value, '')]"
+    },
+    "PG_SERVER_NAME_B": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgServerNameB.value, '')]"
+    },
+    "PG_SERVER_FQDN_B": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgServerFqdnB.value, '')]"
+    },
+    "PG_ADMIN_USER": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgAdminUser.value, '')]"
+    },
+    "PG_DATABASE_COUNT_PER_SERVER": {
+      "type": "int",
+      "value": "[if(and(parameters('deployPostgreSQL'), not(equals(parameters('pgAdminPassword'), ''))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'postgresql'), '2025-04-01').outputs.pgDatabaseCountPerServer.value, 0)]"
     }
   }
 }

--- a/infra/modules/database.bicep
+++ b/infra/modules/database.bicep
@@ -28,29 +28,14 @@ param vnetId string = ''
 @description('Private endpoint subnet ID (required when usePrivateEndpoint is true)')
 param privateEndpointSubnetId string = ''
 
-var resourceGroupNameVar = '${namePrefix}-rg'
 var sqlserverNameVar = '${namePrefix}sql'
 var sqlpoolNameVar = '${namePrefix}pool'
 var identityNameVar = '${namePrefix}identity'
+var vnetNameVar = '${namePrefix}vnet'
 var subnetNamesArray = split(subnetNames,',')
 
-
-module networkResource 'network.bicep' = {
-  name: 'networkResource'
-  scope: resourceGroup(resourceGroupNameVar)
-  params: {
-    namePrefix: namePrefix
-    location: location
-  }
-}
-
-module identityResource 'identity.bicep' = {
-  name: 'identityResource'
-  scope: resourceGroup(resourceGroupNameVar)
-  params: {
-    identityName: identityNameVar
-    location: location
-  }
+resource existingVnet 'Microsoft.Network/virtualNetworks@2023-05-01' existing = {
+  name: vnetNameVar
 }
 
 
@@ -92,7 +77,7 @@ resource sqlserverA_VnetRule 'Microsoft.Sql/servers/virtualNetworkRules@2021-11-
   name: '${sqlserverNameVar}A_${subnet}'
   properties: {
     ignoreMissingVnetServiceEndpoint: false
-    virtualNetworkSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets',networkResource.outputs.vnetName, subnet)
+    virtualNetworkSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', existingVnet.name, subnet)
 
   }
 }]
@@ -171,7 +156,7 @@ resource sqlserverB_VnetRule 'Microsoft.Sql/servers/virtualNetworkRules@2021-11-
   name: '${sqlserverNameVar}B_${subnet}'
   properties: {
     ignoreMissingVnetServiceEndpoint: false
-    virtualNetworkSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets',networkResource.outputs.vnetName, subnet)
+    virtualNetworkSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', existingVnet.name, subnet)
 
   }
 }]

--- a/scripts/tests/run_all_external_tests_in_aci.ps1
+++ b/scripts/tests/run_all_external_tests_in_aci.ps1
@@ -3,6 +3,24 @@ param (
     [Parameter()]
     [string] $prefix 
 )
+
+# Resolve prefix: parameter > azd env AZURE_NAME_PREFIX
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    $prefix = azd env get-value AZURE_NAME_PREFIX 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($prefix)) {
+        $prefix = $null
+    } else {
+        Write-Host "Using prefix '$prefix' from azd environment variable AZURE_NAME_PREFIX" -ForegroundColor DarkGreen
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    Write-Host "ERROR: The -prefix parameter is required." -ForegroundColor Red
+    Write-Host "  Provide it as a parameter:  .\run_all_external_tests_in_aci.ps1 -prefix <your-prefix>" -ForegroundColor Yellow
+    Write-Host "  Or set it in your azd environment:  azd env set AZURE_NAME_PREFIX <your-prefix>" -ForegroundColor Yellow
+    exit 1
+}
+
 $exitCode = 0
 $timestamp = (Get-Date -Format 'yyyy-MM-dd-HHmmss')
 Clear-Host 

--- a/scripts/tests/run_dependent_tests_in_aci.ps1
+++ b/scripts/tests/run_dependent_tests_in_aci.ps1
@@ -1,6 +1,6 @@
  param
 (
-    [Parameter(Mandatory=$true)]
+    [Parameter()]
     [string] $prefix,
 
     [string] $resourceGroupName,
@@ -60,6 +60,23 @@
 #>
 
 $ErrorActionPreference = "Stop"
+
+# Resolve prefix: parameter > azd env AZURE_NAME_PREFIX
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    $prefix = azd env get-value AZURE_NAME_PREFIX 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($prefix)) {
+        $prefix = $null
+    } else {
+        Write-Host "Using prefix '$prefix' from azd environment variable AZURE_NAME_PREFIX" -ForegroundColor DarkGreen
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    Write-Host "ERROR: The -prefix parameter is required." -ForegroundColor Red
+    Write-Host "  Provide it as a parameter:  .\run_dependent_tests_in_aci.ps1 -prefix <your-prefix>" -ForegroundColor Yellow
+    Write-Host "  Or set it in your azd environment:  azd env set AZURE_NAME_PREFIX <your-prefix>" -ForegroundColor Yellow
+    exit 1
+}
 
 Clear-Host 
 

--- a/src/SqlBuildManager.Console/Batch/BatchManager.cs
+++ b/src/SqlBuildManager.Console/Batch/BatchManager.cs
@@ -707,6 +707,24 @@ namespace SqlBuildManager.Console.Batch
                             }
                         }
                         
+                        // Check if network configuration matches (subnet is immutable — requires pool recreation)
+                        var existingSubnetId = poolresult.Value.Data.NetworkConfiguration?.SubnetId?.ToString();
+                        var requestedSubnetId = data.NetworkConfiguration?.SubnetId?.ToString();
+                        bool networkMismatch = !string.Equals(existingSubnetId ?? "", requestedSubnetId ?? "", StringComparison.OrdinalIgnoreCase);
+
+                        if (networkMismatch)
+                        {
+                            log.LogWarning($"The pool {poolId} network configuration does not match. Existing subnet: '{existingSubnetId ?? "none"}', Requested subnet: '{requestedSubnetId ?? "none"}'");
+                            log.LogWarning($"Deleting pool {poolId} to recreate with correct network configuration (subnet is immutable)...");
+                            await poolresult.Value.DeleteAsync(Azure.WaitUntil.Completed);
+                            log.LogInformation($"Pool {poolId} deleted. Recreating with correct network configuration...");
+
+                            ArmOperation<BatchAccountPoolResource> lro = await collection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, poolId, data);
+                            BatchAccountPoolResource result = lro.Value;
+                            log.LogInformation($"Successfully recreated {os} pool {poolId} with {nodeCount} nodes");
+                            return true;
+                        }
+
                         // Check if User-Assigned Managed Identity needs to be assigned
                         var requestedIdentityResourceId = new ResourceIdentifier(cmdLine.IdentityArgs.ResourceId);
                         bool identityAssigned = poolresult.Value.Data.Identity?.UserAssignedIdentities?.ContainsKey(requestedIdentityResourceId) == true;

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Aci.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Aci.cs
@@ -48,6 +48,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(DatabaseAuthArgs);
                 cmd.AddRange(IdentityArgumentsForContainerApp);
                 cmd.AddRange(ContainerRegistryAndImageOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Settings File", new List<Option> { settingsfileNewOption }),
+                    new OptionGroup("ACI", new List<Option> { aciIResourceGroupNameOption, aciInstanceNameOption, subscriptionIdOption }),
+                    new OptionGroup("Execution", new List<Option> { sectionPlaceholderOption, defaultscripttimeoutOption, timeoutretrycountOption, silentOption, cleartextOption }),
+                    new OptionGroup("Connections & Secrets", new List<Option> { keyVaultNameOption, storageaccountnameOption, storageaccountkeyOption, eventhubconnectionOption, serviceBusconnectionOption }),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("VNET", VnetOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Identity", IdentityArgumentsForContainerApp),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions)
+                );
                 cmd.SetAction((parseResult) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var clearText = parseResult.GetValue(cleartextOption);
@@ -96,6 +107,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(identityResourceGroupOption);
                 cmd.Add(subscriptionIdOption);
                 cmd.AddRange(ConcurrencyRequiredOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { jobnameRequiredOption, packagenameAsFileToUploadOption, overrideRequiredOption, platinumdacpacFileInfoOption, allowForObjectDeletionOption, aciMonitorOption, forceOption }),
+                    new OptionGroup("ACI", new List<Option> { aciIResourceGroupNameNotReqOption, aciInstanceNameNotReqOption, aciContainerCountOption }),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("VNET", VnetOptions),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Connections & Secrets", new List<Option> { keyVaultNameOption, storageaccountnameOption, storageaccountkeyOption }),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Identity", new List<Option> { clientIdOption, identityNameOption, identityResourceGroupOption, subscriptionIdOption }),
+                    new OptionGroup("Concurrency", ConcurrencyRequiredOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var packagename = parseResult.GetValue(packagenameAsFileToUploadOption);
@@ -148,7 +170,19 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(subscriptionIdOption);
                 cmd.AddRange(ConcurrencyRequiredOptions);
                 cmd.Add(streamEventsOption);
-
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Query", new List<Option> { overrideRequiredOption, queryFileOption, outputFileOption }),
+                    new OptionGroup("ACI", new List<Option> { aciIResourceGroupNameNotReqOption, aciInstanceNameNotReqOption, aciContainerCountOption }),
+                    new OptionGroup("Execution", new List<Option> { jobnameOption, aciMonitorOption, forceOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("VNET", VnetOptions),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Connections & Secrets", new List<Option> { keyVaultNameOption, storageaccountnameOption, storageaccountkeyOption }),
+                    new OptionGroup("Authentication", new List<Option> { authtypeOption, platformOption }),
+                    new OptionGroup("Identity", new List<Option> { clientIdOption, identityNameOption, identityResourceGroupOption, subscriptionIdOption }),
+                    new OptionGroup("Concurrency", ConcurrencyRequiredOptions)
+                );
 
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
@@ -257,6 +291,18 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(clientIdOption);
                 cmd.Add(subscriptionIdOption);
                 cmd.AddRange(ConcurrencyRequiredOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { jobnameRequiredOption, packagenameAsFileToUploadOption, overrideOption, platinumdacpacFileInfoOption, allowForObjectDeletionOption, aciMonitorOption }),
+                    new OptionGroup("ACI", new List<Option> { aciIResourceGroupNameNotReqOption, aciInstanceNameNotReqOption, aciContainerCountOption }),
+                    new OptionGroup("Settings File", new List<Option> { settingsfileExistingOption }),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("VNET", VnetOptions),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Connections & Secrets", new List<Option> { keyVaultNameOption, storageaccountnameOption, storageaccountkeyOption }),
+                    new OptionGroup("Authentication", new List<Option> { authtypeOption, platformOption }),
+                    new OptionGroup("Identity", new List<Option> { identityNameOption, identityResourceGroupOption, clientIdOption, subscriptionIdOption }),
+                    new OptionGroup("Concurrency", ConcurrencyRequiredOptions)
+                );
 
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Batch.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Batch.cs
@@ -50,6 +50,18 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(IdentityArgumentsForBatch);
                 cmd.AddRange(ConcurrencyOptions);
                 cmd.AddRange(EventHubResourceOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { overrideRequiredOption, packagenameNotReqOption, rootloggingpathOption, defaultscripttimeoutOption, batchJobMonitorTimeoutMin, batchMonitorOption }),
+                    new OptionGroup("DACPAC", new List<Option> { platinumdacpacOption, targetdacpacOption, forcecustomdacpacOption, platinumdbsourceOption, platinumserversourceOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Batch Settings", BatchSettingsOptions),
+                    new OptionGroup("Batch Compute", BatchComputeOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptionsForBatch),
+                    new OptionGroup("Identity", IdentityArgumentsForBatch),
+                    new OptionGroup("Concurrency", ConcurrencyOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var unittest = parseResult.GetValue(unitTestOption);
@@ -205,6 +217,16 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(IdentityArgumentsForBatch);
                 cmd.AddRange(ConcurrencyOptions);
                 cmd.AddRange(EventHubResourceOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Settings File", SettingsFileNewOptions),
+                    new OptionGroup("Execution", new List<Option> { deletebatchjobOption, rootloggingpathOption, defaultscripttimeoutOption, timeoutretrycountOption, pollbatchpoolstatusOption, silentOption, cleartextOption }),
+                    new OptionGroup("Batch Compute", BatchComputeOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptionsForBatch),
+                    new OptionGroup("Identity", IdentityArgumentsForBatch),
+                    new OptionGroup("Concurrency", ConcurrencyOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions)
+                );
                 cmd.SetAction((parseResult) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var clearText = parseResult.GetValue(cleartextOption);
@@ -289,6 +311,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(ConnectionAndSecretsOptionsForBatch);
                 cmd.AddRange(IdentityArgumentsForBatch);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Query", new List<Option> { overrideRequiredOption, queryFileRequiredOption, outputFileRequiredOption, silentOption }),
+                    new OptionGroup("Batch Settings", new List<Option> { deletebatchjobOption, jobnameOption, rootloggingpathOption, defaultscripttimeoutOption, batchMonitorOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Batch Compute", BatchComputeOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptionsForBatch),
+                    new OptionGroup("Identity", IdentityArgumentsForBatch),
+                    new OptionGroup("Concurrency", ConcurrencyOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var unittest = parseResult.GetValue(unitTestOption);

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.ContainerApp.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.ContainerApp.cs
@@ -36,6 +36,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(DatabaseAuthArgs);
                 cmd.AddRange(ContainerRegistryAndImageOptions);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Settings File", SettingsFileNewOptions),
+                    new OptionGroup("Execution", new List<Option> { defaultscripttimeoutOption, cleartextOption, silentOption }),
+                    new OptionGroup("Container App", ContainerAppOptions),
+                    new OptionGroup("Identity", IdentityArgumentsForContainerApp),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
                 cmd.SetAction((parseResult) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var clearText = parseResult.GetValue(cleartextOption);
@@ -79,6 +90,18 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.AddRange(DatabaseAuthArgs);
                 cmd.AddRange(ContainerRegistryAndImageOptions);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { packagenameOption, platinumdacpacOption, defaultscripttimeoutOption, overrideOption, jobnameRequiredOption, decryptedOption, allowForObjectDeletionOption, forceOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Container App", ContainerAppOptions),
+                    new OptionGroup("Container App Execution", new List<Option> { containerAppMonitorOption, containerAppDeleteAppUponCompletion }),
+                    new OptionGroup("Identity", IdentityArgumentsForContainerApp),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var unittest = parseResult.GetValue(unitTestOption);
@@ -181,6 +204,18 @@ namespace SqlBuildManager.Console.CommandLine
 
                 cmd.AddRange(ContainerRegistryAndImageOptions);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { packagenameOption, platinumdacpacOption, defaultscripttimeoutOption, overrideOption, jobnameRequiredOption, decryptedOption, allowForObjectDeletionOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Container App", ContainerAppOptions),
+                    new OptionGroup("Container App Execution", new List<Option> { containerAppMonitorOption, containerAppDeleteAppUponCompletion }),
+                    new OptionGroup("Identity", IdentityArgumentsForContainerApp),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Container Registry", ContainerRegistryAndImageOptions),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var unittest = parseResult.GetValue(unitTestOption);

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Kubernetes.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.Kubernetes.cs
@@ -53,6 +53,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(subscriptionIdOption);
                 cmd.Add(unitTestOption);
 
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { jobnameOption, overrideAsFileOption, packagenameAsFileToUploadOption, platinumdacpacFileInfoOption, forceOption, allowForObjectDeletionOption, k8sCleanupOnFailureOption }),
+                    new OptionGroup("Kubernetes", new List<Option> { podCountOption, subscriptionIdOption }),
+                    new OptionGroup("Container Registry", new List<Option> { imageTagOption, imageNameOption, imageRepositoryOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Identity", IdentityArgumentsForKubernetes),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
 
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
@@ -103,6 +114,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(subscriptionIdOption);
                 cmd.Add(unitTestOption);
 
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Query", new List<Option> { overrideRequiredOption, queryFileOption, outputFileOption }),
+                    new OptionGroup("Kubernetes", new List<Option> { podCountOption, k8sCleanupOnFailureOption, subscriptionIdOption }),
+                    new OptionGroup("Container Registry", new List<Option> { imageTagOption, imageNameOption, imageRepositoryOption }),
+                    new OptionGroup("Settings File", SettingsFileExistingOptions),
+                    new OptionGroup("Identity", IdentityArgumentsForKubernetes),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
 
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
@@ -255,6 +277,17 @@ namespace SqlBuildManager.Console.CommandLine
                 cmd.Add(clientIdOption);
                 cmd.Add(cleartextOption);
 
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Settings File", SettingsFileNewOptions),
+                    new OptionGroup("Kubernetes", new List<Option> { podCountOption, subscriptionIdOption }),
+                    new OptionGroup("Container Registry", new List<Option> { imageTagOption, imageNameOption, imageRepositoryOption }),
+                    new OptionGroup("Identity", new List<Option> { serviceAccountNameOption, tenantIdOption, identityNameNotReqOption, identityResourceGroupNotReqOption, clientIdOption }),
+                    new OptionGroup("Connections & Secrets", ConnectionAndSecretsOptions),
+                    new OptionGroup("Event Hub", EventHubResourceOptions),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Concurrency", ConcurrencyOptions),
+                    new OptionGroup("Execution", new List<Option> { silentOption, cleartextOption })
+                );
 
                 cmd.SetAction((parseResult) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.LocalAndThreaded.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.LocalAndThreaded.cs
@@ -32,6 +32,12 @@ namespace SqlBuildManager.Console.CommandLine
                     timeoutretrycountOption
                 };
                 cmd.AddRange(DatabaseAuthArgs);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Database Connection", new List<Option> { serverOption, databaseOption }),
+                    new OptionGroup("Build Options", new List<Option> { packagenameOption, overrideOption, trialOption, transactionalOption, descriptionOption, buildrevisionOption, scriptsrcdirOption, timeoutretrycountOption }),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Logging", new List<Option> { rootloggingpathOption, logtodatabasenamedOption })
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     return await Worker.RunLocalBuildAsync(cmdLine);
@@ -69,6 +75,13 @@ namespace SqlBuildManager.Console.CommandLine
                 };
                 cmd.AddRange(DatabaseAuthArgs);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Build Options", new List<Option> { packagenameOption, overrideOption, trialOption, transactionalOption, descriptionOption, buildrevisionOption, scriptsrcdirOption, timeoutretrycountOption, defaultscripttimeoutOption }),
+                    new OptionGroup("DACPAC", new List<Option> { platinumdacpacOption, targetdacpacOption, forcecustomdacpacOption, platinumdbsourceOption, platinumserversourceOption }),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Concurrency", ConcurrencyOptions),
+                    new OptionGroup("Logging", new List<Option> { rootloggingpathOption, logtodatabasenamedOption })
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     var unittest = parseResult.GetValue(unitTestOption);
@@ -95,6 +108,12 @@ namespace SqlBuildManager.Console.CommandLine
                 };
                 cmd.AddRange(DatabaseAuthArgs);
                 cmd.AddRange(ConcurrencyOptions);
+                cmd.SetGroupedHelp(
+                    new OptionGroup("Query", new List<Option> { queryFileRequiredOption, outputFileRequiredOption, silentOption }),
+                    new OptionGroup("Database Targets", new List<Option> { overrideRequiredOption, defaultscripttimeoutOption }),
+                    new OptionGroup("Authentication", DatabaseAuthArgs),
+                    new OptionGroup("Concurrency", ConcurrencyOptions)
+                );
                 cmd.SetAction(async (parseResult, ct) => {
                     var cmdLine = CommandLineArgsBinder.Bind(parseResult);
                     return await Worker.QueryDatabasesAsync(cmdLine);

--- a/src/SqlBuildManager.Console/CommandLine/Extensions.cs
+++ b/src/SqlBuildManager.Console/CommandLine/Extensions.cs
@@ -4,6 +4,7 @@ using SqlBuildManager.Console.ContainerApp.Internal;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Help;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
@@ -302,6 +303,19 @@ namespace SqlBuildManager.Console.CommandLine
             cmd.Add(opt);
          }
       }
+
+      /// <summary>
+      /// Registers a custom grouped help action on the command, replacing the default help rendering.
+      /// Options are displayed under named group headings for improved readability.
+      /// </summary>
+      public static void SetGroupedHelp(this Command command, params OptionGroup[] groups)
+      {
+         var helpOption = new HelpOption();
+         var defaultHelp = (HelpAction)helpOption.Action!;
+         helpOption.Action = new GroupedHelpAction(defaultHelp, groups.ToList());
+         command.Add(helpOption);
+      }
+
       public static string Quoted(this string str)
       {
          return "\"" + str + "\"";

--- a/src/SqlBuildManager.Console/CommandLine/GroupedHelpAction.cs
+++ b/src/SqlBuildManager.Console/CommandLine/GroupedHelpAction.cs
@@ -1,0 +1,116 @@
+using Spectre.Console;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Linq;
+
+namespace SqlBuildManager.Console.CommandLine
+{
+    internal class GroupedHelpAction : SynchronousCommandLineAction
+    {
+        private readonly HelpAction _defaultHelp;
+        private readonly List<OptionGroup> _groups;
+
+        public GroupedHelpAction(HelpAction defaultHelp, List<OptionGroup> groups)
+        {
+            _defaultHelp = defaultHelp;
+            _groups = groups;
+        }
+
+        public override int Invoke(ParseResult parseResult)
+        {
+            var command = parseResult.CommandResult.Command;
+
+            if (_groups.Count == 0)
+            {
+                return _defaultHelp.Invoke(parseResult);
+            }
+
+            // Description
+            if (!string.IsNullOrEmpty(command.Description))
+            {
+                AnsiConsole.MarkupLine("[bold]Description:[/]");
+                AnsiConsole.MarkupLine($"  {Markup.Escape(command.Description)}");
+                AnsiConsole.WriteLine();
+            }
+
+            // Usage line
+            AnsiConsole.MarkupLine("[bold]Usage:[/]");
+            var parentNames = GetCommandPath(parseResult);
+            AnsiConsole.MarkupLine($"  {Markup.Escape(parentNames)} [[options]]");
+            AnsiConsole.WriteLine();
+
+            // Track which options are in a group
+            var groupedOptions = _groups.SelectMany(g => g.Options).ToHashSet();
+
+            foreach (var group in _groups)
+            {
+                AnsiConsole.MarkupLine($"[bold]{Markup.Escape(group.Name)}:[/]");
+                foreach (var opt in group.Options)
+                {
+                    if (opt.Hidden) continue;
+                    RenderOption(opt);
+                }
+                AnsiConsole.WriteLine();
+            }
+
+            // Render ungrouped, non-hidden options (--help, --version, etc.)
+            var ungrouped = command.Options
+                .Where(o => !groupedOptions.Contains(o) && !o.Hidden)
+                .ToList();
+
+            if (ungrouped.Count > 0)
+            {
+                AnsiConsole.MarkupLine("[bold]Other Options:[/]");
+                foreach (var opt in ungrouped)
+                {
+                    RenderOption(opt);
+                }
+                AnsiConsole.WriteLine();
+            }
+
+            // Arguments
+            var arguments = command.Arguments.Where(a => !a.Hidden).ToList();
+            if (arguments.Count > 0)
+            {
+                AnsiConsole.MarkupLine("[bold]Arguments:[/]");
+                foreach (var arg in arguments)
+                {
+                    var name = $"<{arg.Name}>";
+                    var desc = arg.Description ?? "";
+                    var paddedName = name.PadRight(38);
+                    AnsiConsole.MarkupLine($"  {Markup.Escape(paddedName)}{Markup.Escape(desc)}");
+                }
+                AnsiConsole.WriteLine();
+            }
+
+            return 0;
+        }
+
+        private static void RenderOption(Option opt)
+        {
+            var allNames = new List<string> { opt.Name };
+            foreach (var alias in opt.Aliases)
+                allNames.Add(alias);
+            var aliases = string.Join(", ", allNames.Distinct().OrderBy(a => a.Length));
+            var desc = opt.Description ?? "";
+            var required = opt.Required ? " [red](required)[/]" : "";
+            var paddedAliases = aliases.PadRight(38);
+            AnsiConsole.MarkupLine($"  {Markup.Escape(paddedAliases)}{Markup.Escape(desc)}{required}");
+        }
+
+        private static string GetCommandPath(ParseResult parseResult)
+        {
+            var parts = new List<string>();
+            var current = parseResult.CommandResult;
+            while (current != null)
+            {
+                parts.Insert(0, current.Command.Name);
+                current = current.Parent as CommandResult;
+            }
+            return string.Join(" ", parts);
+        }
+    }
+}

--- a/src/SqlBuildManager.Console/CommandLine/OptionGroup.cs
+++ b/src/SqlBuildManager.Console/CommandLine/OptionGroup.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace SqlBuildManager.Console.CommandLine
+{
+    /// <summary>
+    /// Associates options with a named group for help display.
+    /// </summary>
+    public class OptionGroup
+    {
+        public string Name { get; }
+        public List<Option> Options { get; }
+
+        public OptionGroup(string name, List<Option> options)
+        {
+            Name = name;
+            Options = options;
+        }
+    }
+}

--- a/src/SqlBuildManager.Console/sbm.csproj
+++ b/src/SqlBuildManager.Console/sbm.csproj
@@ -34,7 +34,7 @@
 		<PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
 		<PackageReference Include="Azure.ResourceManager" Version="1.14.0" />
-		<PackageReference Include="Azure.ResourceManager.AppContainers" Version="1.5.0" />
+		<PackageReference Include="Azure.ResourceManager.AppContainers" Version="1.4.1" />
 		<PackageReference Include="Azure.ResourceManager.Batch" Version="1.6.0" />
 		<PackageReference Include="Azure.ResourceManager.ContainerInstance" Version="1.3.0" />
 		<PackageReference Include="Azure.ResourceManager.EventHubs" Version="1.2.1" />

--- a/src/SqlSync.Connection/SqlSync.Connection.csproj
+++ b/src/SqlSync.Connection/SqlSync.Connection.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
@@ -7,7 +7,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
   </ItemGroup>

--- a/src/SqlSync.ObjectScript/SqlSync.ObjectScript.csproj
+++ b/src/SqlSync.ObjectScript/SqlSync.ObjectScript.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.15.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SqlSync.Connection\SqlSync.Connection.csproj" />

--- a/src/SqlSync.SqlBuild.Dependent.UnitTest/SqlSync.SqlBuild.Dependent.UnitTest.csproj
+++ b/src/SqlSync.SqlBuild.Dependent.UnitTest/SqlSync.SqlBuild.Dependent.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -31,7 +31,7 @@
     <EmbeddedResource Include="Resources\XmlWithNoNamespace.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />

--- a/src/SqlSync.SqlBuild.UnitTest/SqlSync.SqlBuild.UnitTest.csproj
+++ b/src/SqlSync.SqlBuild.UnitTest/SqlSync.SqlBuild.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -22,7 +22,7 @@
     <EmbeddedResource Include="Resources\serialized_multidb_xml.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />

--- a/src/SqlSync.SqlBuild/SqlSync.SqlBuild.csproj
+++ b/src/SqlSync.SqlBuild/SqlSync.SqlBuild.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <EmbeddedResource Include="Status\Xml\ServerReport_summary.xslt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.3.93" />
     <PackageReference Include="Polly" Version="8.6.6" />


### PR DESCRIPTION
This pull request introduces several improvements across infrastructure, scripts, and the .NET command-line interface. The main changes include enhanced validation and usability for test scripts, improved command-line help organization via grouped options, infrastructure refactoring for VNet/subnet handling, and a fix to ensure Azure Batch pools are recreated if their network configuration changes.

**Infrastructure and Azure Resource Management**

* Refactored the VNet/subnet handling in `database.bicep` to use an existing VNet resource instead of deploying a new network module. This simplifies the deployment and ensures correct references in virtual network rules. [[1]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L31-R38) [[2]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L95-R80) [[3]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L174-R159)
* Added a dependency on `identityResource` for the `databases` module in `main.bicep` to ensure proper deployment order.

**Azure Batch Pool Management**

* Updated `BatchManager.cs` to detect mismatches in subnet configuration for Batch pools. If a mismatch is found (since subnets are immutable), the pool is deleted and recreated with the correct network configuration.

**Command-Line Interface Usability**

* Introduced grouped help sections for all major commands in the .NET CLI (`CommandLineBuilder.Aci.cs`, `CommandLineBuilder.Batch.cs`, `CommandLineBuilder.ContainerApp.cs`). This organizes options into logical groups, making help output much easier to read and use. [[1]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R51-R61) [[2]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R110-R120) [[3]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9L151-R185) [[4]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R294-R305) [[5]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R53-R64) [[6]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R220-R229) [[7]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R314-R324) [[8]](diffhunk://#diff-9e6ce668d0ba9daaae7275739b2e29b444df87a8efe2ccfbe2d4c760f4d85a55R39-R49) [[9]](diffhunk://#diff-9e6ce668d0ba9daaae7275739b2e29b444df87a8efe2ccfbe2d4c760f4d85a55R93-R104)

**Test Script Improvements**

* Enhanced both `run_all_external_tests_in_aci.ps1` and `run_dependent_tests_in_aci.ps1` to resolve the `-prefix` parameter from the environment variable `AZURE_NAME_PREFIX` if not provided, and display clear error messages if missing. This improves script robustness and user experience. [[1]](diffhunk://#diff-cc34d26ca69734cb5f841ffae7d2961426b21ac493f474f25b5aa46ab80be424R6-R23) [[2]](diffhunk://#diff-0ebe723dd5aac73e34c6f4e75ff9868f7a5f5d6b7a29e0964e21d8eeb4449969L3-R3) [[3]](diffhunk://#diff-0ebe723dd5aac73e34c6f4e75ff9868f7a5f5d6b7a29e0964e21d8eeb4449969R64-R80)

---

**Infrastructure improvements:**
- Switched VNet/subnet references in `database.bicep` to use an existing VNet resource, simplifying deployments and ensuring correct subnet IDs in SQL server VNet rules. [[1]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L31-R38) [[2]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L95-R80) [[3]](diffhunk://#diff-b34878a6c97d46421c1504f5ff7a9b75917f751c77e5bc984e0d8a4f979bdb58L174-R159)
- Added `dependsOn` for `identityResource` in the `databases` module within `main.bicep` to ensure correct deployment sequencing.

**Azure Batch enhancements:**
- Added logic to `BatchManager.cs` to detect and correct subnet mismatches for Batch pools by deleting and recreating the pool if necessary.

**CLI usability:**
- Grouped command-line options into logical sections for all major commands, providing clearer help output and improving user experience. [[1]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R51-R61) [[2]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R110-R120) [[3]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9L151-R185) [[4]](diffhunk://#diff-0d170fe9aff4740092c751518e883683163ea394c9a813becf8cbee38f110af9R294-R305) [[5]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R53-R64) [[6]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R220-R229) [[7]](diffhunk://#diff-7dc6907bb6db04ab5f691877100f72d216492e90d57737c39403edbeefdf49c7R314-R324) [[8]](diffhunk://#diff-9e6ce668d0ba9daaae7275739b2e29b444df87a8efe2ccfbe2d4c760f4d85a55R39-R49) [[9]](diffhunk://#diff-9e6ce668d0ba9daaae7275739b2e29b444df87a8efe2ccfbe2d4c760f4d85a55R93-R104)

**Test script robustness:**
- Improved test scripts to auto-resolve the `-prefix` parameter from the environment or prompt the user, reducing errors and setup friction. [[1]](diffhunk://#diff-cc34d26ca69734cb5f841ffae7d2961426b21ac493f474f25b5aa46ab80be424R6-R23) [[2]](diffhunk://#diff-0ebe723dd5aac73e34c6f4e75ff9868f7a5f5d6b7a29e0964e21d8eeb4449969L3-R3) [[3]](diffhunk://#diff-0ebe723dd5aac73e34c6f4e75ff9868f7a5f5d6b7a29e0964e21d8eeb4449969R64-R80)