### PR TITLE
Security hardening: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SQL Build Manager Change Log
 
+### Unreleased — Security hardening
+- **SECURITY:** Secrets are now masked in all log output. Account/SAS/shared-access **keys** are shown as their first 4 characters with the remainder replaced by `x`; **passwords** show only their first and last character; **connection strings** have their embedded secrets masked the same way. The Batch storage **SAS token** is no longer logged at all (only the storage account name is). This prevents credential leakage through Log Analytics, Batch node logs, and support bundles.
+- **SECURITY (breaking default):** New `--trustservercertificate` / `--trustcert` flag (SQL Server only, default **`false`**). Previously SQL Server connections **always** trusted the server certificate, which allowed man-in-the-middle attacks. TLS certificates are now validated by default; set the flag (or `TrustServerCertificate: true` in the settings file under `AuthenticationArgs`) to opt back in when connecting to servers with self-signed/dev certificates. PostgreSQL is unaffected (it uses `SslMode`).
+- **SECURITY:** Settings-file encryption strengthened. New values use a random salt and IV per encryption (non-deterministic output), PBKDF2-SHA256 with 100,000 iterations, and an HMAC-SHA256 authentication tag (encrypt-then-MAC) so tampering and wrong passwords are reliably detected. **Existing encrypted settings files remain readable** and are transparently upgraded to the new format the next time they are saved.
+
 ### [Version 16.0.0](https://github.com/mmckechney/SqlBuildManager/releases/tag/v16.0.0)
 - *NEW:* Major updated to support PostgreSQL database in addition to SQL Server
 - *NEW:* Added new scripts [/scripts/tests](scripts/tests) to run all unit tests, local integration tests and external (Azure targeted) tests in Azure Container Instance Linux containers. There area additional new scripts in [scripts/ContainerRegistry](scripts/ContainerRegistry) to build two new containers (one for Unit and Local tests and one for External tests). The underlying tests were updated to run on both Linux and Windows.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ With this update, it significantly reduces the the need to save and manage secre
     - [**Remote Build Execution**](#remote-build-execution)
     - [**"Settings" file**](#settings-file)
     - [**"jobname"**](#jobname)
+    - [**Security**](#security)
   - [Key Features](#key-features)
   - [Running Builds (command line)](#running-builds-command-line)
     - [**Local**](#local)
@@ -90,6 +91,14 @@ A configuration file that can be saved and re-used across multiple builds. It sa
 ### **"jobname"**
 
 The name of a build. This is used as the name or name prefix for all of the Azure services used in a remote build including the blob storage container, running docker containers, service bus topic, etc.
+
+### **Security**
+
+SQL Build Manager is an operator-run tool that handles connection strings, account keys and SAS tokens. A few behaviors are worth understanding:
+
+- **Secrets are masked in logs.** Account/access keys are shown as their first 4 characters followed by `x`'s, passwords as their first and last character with the middle masked, and connection strings have their embedded secrets masked the same way. SAS tokens are never logged (only the storage account name is). This prevents credential leakage through log aggregation, Batch node logs, or support bundles.
+- **Settings-file encryption.** Sensitive values in a settings file are protected with AES-256 using a random salt and IV per value, PBKDF2-SHA256 (100,000 iterations) key derivation, and an HMAC integrity check. Existing settings files created by earlier versions remain readable and are upgraded to the stronger format the next time the file is saved.
+- **TLS certificate validation (`--trustservercertificate`).** Database server certificates are validated by default. If you connect to a server with a self-signed or otherwise untrusted certificate (common for local SQL Express), pass `--trustservercertificate true` to opt in to trusting it. This setting can also be stored in the settings file.
 
 ---
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -205,6 +205,7 @@ These options apply to `build`, `threaded run`, and the remote execution command
 | `--authtype` | enum | `Password` | Authentication method: `Password`, `Windows`, `ManagedIdentity`, `AzureADPassword`, `AzureADIntegrated`, `AzureADDefault`, `AzureADInteractive` |
 | `--username` / `-u` | string | | Database username (required for `Password` and `AzureADPassword` auth types) |
 | `--password` / `-p` | string | | Database password (required for `Password` and `AzureADPassword` auth types) |
+| `--trustservercertificate` / `--trustcert` | bool | `false` | SQL Server only. When `true`, skips TLS certificate validation (`TrustServerCertificate=true`). Default validates the server certificate; only enable for trusted networks or self-signed certificates you control. |
 | `--identityclientid` / `--clientid` | string | | Client ID of the Azure User Assigned Managed Identity |
 | `--tenantid` | string | | Azure AD Tenant ID (optional, for explicit tenant targeting) |
 

--- a/src/SqlBuildManager.Console/BackoutCommandLine.cs
+++ b/src/SqlBuildManager.Console/BackoutCommandLine.cs
@@ -22,6 +22,7 @@ namespace SqlBuildManager.Console
             }
 
             ConnectionData connectionData = new ConnectionData(cmdLine.Server, cmdLine.Database);
+            connectionData.TrustServerCertificate = cmdLine.AuthenticationArgs.TrustServerCertificate;
             if (cmdLine.AuthenticationArgs.Password.Length > 0)
                 connectionData.Password = cmdLine.AuthenticationArgs.Password;
             if (cmdLine.AuthenticationArgs.UserName.Length > 0)

--- a/src/SqlBuildManager.Console/Batch/BatchManager.cs
+++ b/src/SqlBuildManager.Console/Batch/BatchManager.cs
@@ -202,7 +202,7 @@ namespace SqlBuildManager.Console.Batch
                     storageCreds = StorageManager.GetStorageSharedKeyCredential(cmdLine.ConnectionArgs.StorageAccountName, cmdLine.ConnectionArgs.StorageAccountKey);
                     containerSasToken = await StorageManager.GetOutputContainerSasUrlAsync(cmdLine.ConnectionArgs.StorageAccountName, cmdLine.ConnectionArgs.StorageAccountKey, storageContainerName, false).ConfigureAwait(false);
                 }
-                log.LogDebug($"Output write SAS token: {containerSasToken}");
+                log.LogDebug($"Generated output write SAS token for storage account '{cmdLine.ConnectionArgs.StorageAccountName}'");
 
 
                 // Get a Batch client using account creds or Managed Identity

--- a/src/SqlBuildManager.Console/CloudStorage/StorageManager.cs
+++ b/src/SqlBuildManager.Console/CloudStorage/StorageManager.cs
@@ -6,6 +6,7 @@ using Azure.Storage.Sas;
 using Microsoft.Azure.Batch;
 using Microsoft.Extensions.Logging;
 using SqlBuildManager.Console.CommandLine;
+using SqlSync.Connection;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -626,7 +627,7 @@ namespace SqlBuildManager.Console.CloudStorage
             {
 
                 var connstr = GetStorageConnectionString(storageAccountName, storageAccountKey);
-                log.LogDebug($"Creating container with account name '{storageAccountName}' and container name '{containerName}' and key '{storageAccountKey}'. ");
+                log.LogDebug($"Creating container with account name '{storageAccountName}' and container name '{containerName}' and key '{ConnectionStringRedactor.MaskKey(storageAccountKey)}'. ");
                 containerClient = new BlobContainerClient(connstr, containerName);
             }
 

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineArgs.Authentication.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineArgs.Authentication.cs
@@ -53,6 +53,17 @@ namespace SqlBuildManager.Console.CommandLine
             }
         }
 
+        [JsonIgnore]
+        public virtual bool TrustServerCertificate
+        {
+            set
+            {
+                if (AuthenticationArgs == null) AuthenticationArgs = new Authentication();
+                AuthenticationArgs.TrustServerCertificate = value;
+                this.DirectPropertyChangeTracker.Add("Authentication.TrustServerCertificate");
+            }
+        }
+
         [Serializable]
         public class Authentication : ArgsBase
         {
@@ -66,6 +77,9 @@ namespace SqlBuildManager.Console.CommandLine
             [JsonConverter(typeof(JsonStringEnumConverter))]
             [DefaultValue(SqlSync.Connection.DatabasePlatform.SqlServer)]
             public SqlSync.Connection.DatabasePlatform DatabasePlatform { get; set; } = SqlSync.Connection.DatabasePlatform.SqlServer;
+
+            [DefaultValue(false)]
+            public bool TrustServerCertificate { get; set; } = false;
         }
     }
 }

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineArgsBinder.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineArgsBinder.cs
@@ -43,6 +43,7 @@ namespace SqlBuildManager.Console.CommandLine
             EnsureInitialized();
             var args = new CommandLineArgs();
             _registry.ApplyValues(parseResult, args);
+            SeedConnectionDefaults(args);
             return args;
         }
 
@@ -56,6 +57,19 @@ namespace SqlBuildManager.Console.CommandLine
 
             EnsureInitialized();
             _registry.ApplyValues(parseResult, args);
+            SeedConnectionDefaults(args);
+        }
+
+        /// <summary>
+        /// Seeds process-wide connection defaults from the fully-resolved arguments (settings file
+        /// merged + CLI overrides applied). Runs for every command so the operator's run-level
+        /// <c>--trustservercertificate</c> choice is honored by all downstream connection paths,
+        /// including helpers that rebuild connections from individual fields rather than a
+        /// <see cref="ConnectionData"/>.
+        /// </summary>
+        private static void SeedConnectionDefaults(CommandLineArgs args)
+        {
+            ConnectionHelper.TrustServerCertificate = args?.AuthenticationArgs?.TrustServerCertificate ?? false;
         }
 
         /// <summary>
@@ -201,6 +215,7 @@ namespace SqlBuildManager.Console.CommandLine
             _registry.Register(CommandLineBuilder.passwordOption, (args, v) => args.Password = v);
             _registry.Register(CommandLineBuilder.authtypeOption, (args, v) => args.AuthenticationType = v);
             _registry.Register(CommandLineBuilder.platformOption, (args, v) => args.DatabasePlatform = v);
+            _registry.Register(CommandLineBuilder.trustServerCertificateOption, (args, v) => args.TrustServerCertificate = v);
         }
 
         #endregion

--- a/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.cs
+++ b/src/SqlBuildManager.Console/CommandLine/CommandLineBuilder.cs
@@ -353,7 +353,8 @@ namespace SqlBuildManager.Console.CommandLine
                     usernameOption,
                     passwordOption,
                     authtypeOption,
-                    platformOption
+                    platformOption,
+                    trustServerCertificateOption
                 };
                 return list;
             }
@@ -362,6 +363,7 @@ namespace SqlBuildManager.Console.CommandLine
         internal static Option<string> passwordOption = new Option<string>("--password", "-p") { Description = "The password to authenticate against the database if not using integrated or Managed Identity auth" };
         internal static Option<SqlSync.Connection.AuthenticationType> authtypeOption = new Option<SqlSync.Connection.AuthenticationType>("--authtype") { Description = "SQL Authentication type to use."  };
         internal static Option<SqlSync.Connection.DatabasePlatform> platformOption = new Option<SqlSync.Connection.DatabasePlatform>("--platform", "--databaseplatform") { Description = "Target database platform (default: SqlServer)." };
+        internal static Option<bool> trustServerCertificateOption = new Option<bool>("--trustservercertificate", "--trustcert") { Description = "SQL Server only. When set, skips TLS certificate validation (TrustServerCertificate=true). Default is false (the server certificate is validated). Only enable for trusted networks or self-signed certificates you control." };
 
         /// <summary>
         /// Container Registry and Image Options including "--imagetag, --imagename, --registryserver, --registryusername, --registrypassword

--- a/src/SqlBuildManager.Console/KeyVault/KeyVaultHelper.cs
+++ b/src/SqlBuildManager.Console/KeyVault/KeyVaultHelper.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Polly;
 using SqlBuildManager.Console.Aad;
 using SqlBuildManager.Console.CommandLine;
+using SqlSync.Connection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -82,7 +83,7 @@ namespace SqlBuildManager.Console.KeyVault
             }
             catch (Exception exe)
             {
-                log.LogError($"Unable to save secret '{secretName}' to vault {keyVaultName}: {exe.ToString()}");
+                log.LogError($"Unable to save secret '{secretName}' to vault {keyVaultName}: [{exe.GetType()}] {exe.Message}");
                 return null!;
             }
         }

--- a/src/SqlBuildManager.Console/Kubernetes/KubernetesManager.cs
+++ b/src/SqlBuildManager.Console/Kubernetes/KubernetesManager.cs
@@ -408,13 +408,13 @@ namespace SqlBuildManager.Console.Kubernetes
          if (File.Exists("/etc/runtime/EventHubConnectionString"))
          {
             args.EventHubConnection = File.ReadAllText("/etc/runtime/EventHubConnectionString");
-            log.LogDebug($"EventHubConnectionString= {args.ConnectionArgs.EventHubConnectionString}");
+            log.LogDebug($"EventHubConnectionString= {ConnectionStringRedactor.RedactConnectionString(args.ConnectionArgs.EventHubConnectionString)}");
          }
 
          if (File.Exists("/etc/runtime/ServiceBusTopicConnectionString"))
          {
             args.ServiceBusTopicConnection = File.ReadAllText("/etc/runtime/ServiceBusTopicConnectionString");
-            log.LogDebug($"ServiceBusTopicConnectionString= {args.ConnectionArgs.ServiceBusTopicConnectionString}");
+            log.LogDebug($"ServiceBusTopicConnectionString= {ConnectionStringRedactor.RedactConnectionString(args.ConnectionArgs.ServiceBusTopicConnectionString)}");
          }
 
          if (File.Exists("/etc/runtime/StorageAccountName"))
@@ -478,29 +478,29 @@ namespace SqlBuildManager.Console.Kubernetes
             if (File.Exists("/etc/sbm/EventHubConnectionString"))
             {
                args.EventHubConnection = File.ReadAllText("/etc/sbm/EventHubConnectionString");
-               log.LogDebug($"eventhub= {args.ConnectionArgs.EventHubConnectionString}");
+               log.LogDebug($"eventhub= {ConnectionStringRedactor.RedactConnectionString(args.ConnectionArgs.EventHubConnectionString)}");
             }
 
             if (File.Exists("/etc/sbm/ServiceBusTopicConnectionString"))
             {
                args.ServiceBusTopicConnection = File.ReadAllText("/etc/sbm/ServiceBusTopicConnectionString");
-               log.LogDebug($"serviceBus= {args.ConnectionArgs.ServiceBusTopicConnectionString}");
+               log.LogDebug($"serviceBus= {ConnectionStringRedactor.RedactConnectionString(args.ConnectionArgs.ServiceBusTopicConnectionString)}");
             }
 
             if (File.Exists("/etc/sbm/StorageAccountKey"))
             {
                args.StorageAccountKey = File.ReadAllText("/etc/sbm/StorageAccountKey");
-               log.LogDebug($"storageaccountkey= {args.ConnectionArgs.StorageAccountKey}");
+               log.LogDebug($"storageaccountkey= {ConnectionStringRedactor.MaskKey(args.ConnectionArgs.StorageAccountKey)}");
             }
 
             if (args.AuthenticationArgs.AuthenticationType != AuthenticationType.ManagedIdentity
                && args.AuthenticationArgs.AuthenticationType != AuthenticationType.AzureADDefault)
             {
                args.Password = File.ReadAllText("/etc/sbm/Password");
-               log.LogDebug($"password= {args.AuthenticationArgs.Password}");
+               log.LogDebug($"password= {ConnectionStringRedactor.MaskPassword(args.AuthenticationArgs.Password)}");
 
                args.UserName = File.ReadAllText("/etc/sbm/UserName");
-               log.LogDebug($"username= {args.AuthenticationArgs.UserName}");
+               log.LogDebug($"username= {ConnectionStringRedactor.MaskPassword(args.AuthenticationArgs.UserName)}");
             }
 
             return (true, args);

--- a/src/SqlBuildManager.Console/Threaded/ThreadedQuery.cs
+++ b/src/SqlBuildManager.Console/Threaded/ThreadedQuery.cs
@@ -39,7 +39,7 @@ namespace SqlBuildManager.Console.Threaded
             }
 
             var query = File.ReadAllText(cmdLine.QueryFile.FullName);
-            var connData = new ConnectionData() { UserId = cmdLine.AuthenticationArgs.UserName, Password = cmdLine.AuthenticationArgs.Password, AuthenticationType = cmdLine.AuthenticationArgs.AuthenticationType, ManagedIdentityClientId = cmdLine.IdentityArgs.ClientId, DatabasePlatform = cmdLine.AuthenticationArgs.DatabasePlatform };
+            var connData = new ConnectionData() { UserId = cmdLine.AuthenticationArgs.UserName, Password = cmdLine.AuthenticationArgs.Password, AuthenticationType = cmdLine.AuthenticationArgs.AuthenticationType, ManagedIdentityClientId = cmdLine.IdentityArgs.ClientId, DatabasePlatform = cmdLine.AuthenticationArgs.DatabasePlatform, TrustServerCertificate = cmdLine.AuthenticationArgs.TrustServerCertificate };
             // For PG MI auth, use identity name as UserId (PG role name)
             if (connData.DatabasePlatform == DatabasePlatform.PostgreSQL
                 && string.IsNullOrEmpty(connData.UserId)

--- a/src/SqlBuildManager.Console/Threaded/ThreadedRunner.cs
+++ b/src/SqlBuildManager.Console/Threaded/ThreadedRunner.cs
@@ -248,6 +248,7 @@ namespace SqlBuildManager.Console.Threaded
                 connData.AuthenticationType = cmdArgs.AuthenticationArgs.AuthenticationType;
                 connData.ManagedIdentityClientId = cmdArgs.IdentityArgs.ClientId;
                 connData.DatabasePlatform = cmdArgs.AuthenticationArgs.DatabasePlatform;
+                connData.TrustServerCertificate = cmdArgs.AuthenticationArgs.TrustServerCertificate;
 
                 // For PG MI auth, use identity name as UserId (PG role name)
                 if (connData.DatabasePlatform == SqlSync.Connection.DatabasePlatform.PostgreSQL

--- a/src/SqlBuildManager.Console/Validation.cs
+++ b/src/SqlBuildManager.Console/Validation.cs
@@ -301,6 +301,7 @@ namespace SqlBuildManager.Console
             connData.Password = cmdLine.AuthenticationArgs.Password;
             connData.AuthenticationType = cmdLine.AuthenticationArgs.AuthenticationType;
             connData.ManagedIdentityClientId = cmdLine.IdentityArgs.ClientId;
+            connData.TrustServerCertificate = cmdLine.AuthenticationArgs.TrustServerCertificate;
 
             return connData;
         }

--- a/src/SqlBuildManager.Console/Worker/Worker.Local.cs
+++ b/src/SqlBuildManager.Console/Worker/Worker.Local.cs
@@ -124,7 +124,8 @@ namespace SqlBuildManager.Console
                     UserId = cmdLine.AuthenticationArgs.UserName,
                     Password = cmdLine.AuthenticationArgs.Password,
                     ManagedIdentityClientId = cmdLine.IdentityArgs.ClientId,
-                    DatabasePlatform = cmdLine.AuthenticationArgs.DatabasePlatform
+                    DatabasePlatform = cmdLine.AuthenticationArgs.DatabasePlatform,
+                    TrustServerCertificate = cmdLine.AuthenticationArgs.TrustServerCertificate
                 };
                 // For PG MI auth, use identity name as UserId (PG role name)
                 if (connData.DatabasePlatform == DatabasePlatform.PostgreSQL

--- a/src/SqlBuildManager.Test.Common/TestEnvironment.cs
+++ b/src/SqlBuildManager.Test.Common/TestEnvironment.cs
@@ -9,6 +9,14 @@ namespace SqlBuildManager.Test.Common
     /// </summary>
     public static class TestEnvironment
     {
+        // Dependent SQL tests run against a local SQL Express instance with a self-signed
+        // certificate. Mirror the operator opting into --trustservercertificate so that helper
+        // paths which rebuild connections from individual fields (e.g. InfoHelper) connect.
+        static TestEnvironment()
+        {
+            ConnectionHelper.TrustServerCertificate = true;
+        }
+
         // SQL Server settings
         public static string SqlServer { get; } = Environment.GetEnvironmentVariable("SBM_TEST_SQL_SERVER") ?? @"(local)\SQLEXPRESS";
         public static string SqlUser { get; } = Environment.GetEnvironmentVariable("SBM_TEST_SQL_USER") ?? string.Empty;
@@ -37,6 +45,7 @@ namespace SqlBuildManager.Test.Common
         public static ConnectionData GetConnectionData(string databaseName)
         {
             var data = new ConnectionData(SqlServer, databaseName);
+            data.TrustServerCertificate = true;
             if (UseSqlAuth)
             {
                 data.AuthenticationType = AuthenticationType.Password;
@@ -48,13 +57,14 @@ namespace SqlBuildManager.Test.Common
 
         /// <summary>
         /// CLI auth arguments for SQL Server tests (--authtype, --username, --password).
+        /// Includes --trustservercertificate because local/dev SQL Server instances use self-signed certs.
         /// </summary>
         public static string[] GetSqlAuthArgs()
         {
             if (UseSqlAuth)
-                return new[] { "--authtype", AuthenticationType.Password.ToString(), "--username", SqlUser, "--password", SqlPassword };
+                return new[] { "--authtype", AuthenticationType.Password.ToString(), "--username", SqlUser, "--password", SqlPassword, "--trustservercertificate", "true" };
             else
-                return new[] { "--authtype", AuthenticationType.Windows.ToString() };
+                return new[] { "--authtype", AuthenticationType.Windows.ToString(), "--trustservercertificate", "true" };
         }
 
         /// <summary>

--- a/src/SqlSync.Connection.Dependent.UnitTest/ConnectionHelperTest.cs
+++ b/src/SqlSync.Connection.Dependent.UnitTest/ConnectionHelperTest.cs
@@ -55,7 +55,7 @@ namespace SqlSync.Connection.Dependent.UnitTest
             int scriptTimeOut = 20;
             bool expected = true;
             bool actual;
-            actual = ConnectionHelper.TestDatabaseConnection(dbName, serverName, TestSqlUser ?? "", TestSqlPassword ?? "", TestAuthType, scriptTimeOut,"");
+            actual = ConnectionHelper.TestDatabaseConnection(dbName, serverName, TestSqlUser ?? "", TestSqlPassword ?? "", TestAuthType, scriptTimeOut,"", true);
             Assert.AreEqual(expected, actual, $"NOTE: If this test fails, please make sure you have {serverName} instance running.");
         }
 
@@ -72,7 +72,8 @@ namespace SqlSync.Connection.Dependent.UnitTest
                 SQLServerName = TestServerName,
                 AuthenticationType = TestAuthType,
                 UserId = TestSqlUser ?? "",
-                Password = TestSqlPassword ?? ""
+                Password = TestSqlPassword ?? "",
+                TrustServerCertificate = true
             };
             bool expected = true;
             bool actual;

--- a/src/SqlSync.Connection.UnitTest/ConnectionHelperAdditionalTest.cs
+++ b/src/SqlSync.Connection.UnitTest/ConnectionHelperAdditionalTest.cs
@@ -32,7 +32,7 @@ namespace SqlSync.Connection.UnitTest
 
             Assert.IsTrue(result.Contains("Authentication=ActiveDirectoryIntegrated"));
             Assert.IsTrue(result.Contains("Integrated Security=True"));
-            Assert.IsTrue(result.Contains("Trust Server Certificate=True"));
+            Assert.IsFalse(result.Contains("Trust Server Certificate=True"), "Should not trust server cert by default (secure-by-default)");
         }
 
         [TestMethod]

--- a/src/SqlSync.Connection.UnitTest/ConnectionHelperTest.cs
+++ b/src/SqlSync.Connection.UnitTest/ConnectionHelperTest.cs
@@ -56,7 +56,7 @@ namespace SqlSync.Connection.UnitTest
         public void GetConnectionStringTest_FromConnectionDataObj()
         {
             ConnectionData connData = new ConnectionData("myserver", "mydatabase");
-            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=20;Trust Server Certificate=True;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=20;Trust Server Certificate=False;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             string actual;
             actual = ConnectionHelper.GetConnectionString(connData);
             Assert.AreEqual(expected, actual);
@@ -70,7 +70,7 @@ namespace SqlSync.Connection.UnitTest
         {
             ConnectionData connData = new ConnectionData("myserver", "mydatabase");
             connData.ScriptTimeout = 40;
-            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=40;Trust Server Certificate=True;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=40;Trust Server Certificate=False;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             string actual;
             actual = ConnectionHelper.GetConnectionString(connData);
             Assert.AreEqual(expected, actual);
@@ -85,7 +85,7 @@ namespace SqlSync.Connection.UnitTest
             connData.AuthenticationType = AuthenticationType.Password;
             connData.UserId = "User";
             connData.Password = "Password";
-            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=User;Password=Password;Pooling=False;Connect Timeout=20;Trust Server Certificate=True;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = String.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=User;Password=Password;Pooling=False;Connect Timeout=20;Trust Server Certificate=False;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             string actual;
             actual = ConnectionHelper.GetConnectionString(connData);
             Assert.AreEqual(expected, actual);
@@ -101,7 +101,7 @@ namespace SqlSync.Connection.UnitTest
             connData.UserId = "User";
             connData.Password = "Password";
             connData.ScriptTimeout = 30;
-            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=User;Password=Password;Pooling=False;Connect Timeout=30;Trust Server Certificate=True;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=User;Password=Password;Pooling=False;Connect Timeout=30;Trust Server Certificate=False;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             string actual = ConnectionHelper.GetConnectionString(connData);
             Assert.AreEqual(expected, actual);
         }
@@ -117,7 +117,7 @@ namespace SqlSync.Connection.UnitTest
             string uid = "userid";
             string pw = "password";
             int scriptTimeOut = 100;
-            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=userid;Password=password;Pooling=False;Connect Timeout=100;Trust Server Certificate=True;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=userid;Password=password;Pooling=False;Connect Timeout=100;Trust Server Certificate=False;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             string actual;
             actual = ConnectionHelper.GetConnectionString(dbName, serverName, uid, pw, AuthenticationType.Password, scriptTimeOut, "");
             Assert.AreEqual(expected, actual);
@@ -134,7 +134,7 @@ namespace SqlSync.Connection.UnitTest
             string uid = "userid";
             string pw = "password";
             int scriptTimeOut = 100;
-            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=userid;Password=password;Pooling=False;Connect Timeout=100;Trust Server Certificate=True;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;User ID=userid;Password=password;Pooling=False;Connect Timeout=100;Trust Server Certificate=False;Authentication=SqlPassword;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             SqlConnection actual;
             actual = ConnectionHelper.GetConnection(dbName, serverName, uid, pw, AuthenticationType.Password, scriptTimeOut,"");
             Assert.IsNotNull(actual);
@@ -151,7 +151,7 @@ namespace SqlSync.Connection.UnitTest
         public void GetConnectionTest_FromConnectionDataObj()
         {
             ConnectionData connData = new ConnectionData("myserver", "mydatabase");
-            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=20;Trust Server Certificate=True;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
+            string expected = string.Format($"Data Source=myserver;Initial Catalog=mydatabase;Integrated Security=True;Pooling=False;Connect Timeout=20;Trust Server Certificate=False;Application Name=\"{appNameString}\";Connect Retry Count=3;Connect Retry Interval=10");
             SqlConnection actual;
             actual = ConnectionHelper.GetConnection(connData);
             Assert.IsNotNull(actual);

--- a/src/SqlSync.Connection.UnitTest/ConnectionStringRedactorTest.cs
+++ b/src/SqlSync.Connection.UnitTest/ConnectionStringRedactorTest.cs
@@ -1,0 +1,116 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SqlSync.Connection.UnitTest
+{
+    [TestClass]
+    public class ConnectionStringRedactorTest
+    {
+        #region MaskKey
+
+        [TestMethod]
+        public void MaskKey_LongValue_KeepsFirstFourCharacters()
+        {
+            string masked = ConnectionStringRedactor.MaskKey("abcdef123456");
+
+            Assert.AreEqual("abcdxxxxxxxx", masked, "Should keep the first 4 chars and mask the rest with lowercase x");
+            Assert.AreEqual(12, masked.Length, "Length should be preserved");
+        }
+
+        [TestMethod]
+        public void MaskKey_ShortValue_IsFullyMasked()
+        {
+            Assert.AreEqual("xxxx", ConnectionStringRedactor.MaskKey("abcd"), "Values of length <= 4 are fully masked");
+            Assert.AreEqual("xx", ConnectionStringRedactor.MaskKey("ab"));
+        }
+
+        [TestMethod]
+        public void MaskKey_NullOrEmpty_ReturnsInput()
+        {
+            Assert.AreEqual(string.Empty, ConnectionStringRedactor.MaskKey(string.Empty));
+            Assert.IsNull(ConnectionStringRedactor.MaskKey(null!));
+        }
+
+        #endregion
+
+        #region MaskPassword
+
+        [TestMethod]
+        public void MaskPassword_LongValue_KeepsFirstAndLastCharacter()
+        {
+            string masked = ConnectionStringRedactor.MaskPassword("SuperSecret");
+
+            Assert.AreEqual("Sxxxxxxxxxt", masked, "Should keep first and last char and mask the middle");
+            Assert.AreEqual(11, masked.Length, "Length should be preserved");
+        }
+
+        [TestMethod]
+        public void MaskPassword_ShortValue_IsFullyMasked()
+        {
+            Assert.AreEqual("xx", ConnectionStringRedactor.MaskPassword("ab"), "Values of length <= 2 are fully masked");
+            Assert.AreEqual("x", ConnectionStringRedactor.MaskPassword("a"));
+        }
+
+        [TestMethod]
+        public void MaskPassword_NullOrEmpty_ReturnsInput()
+        {
+            Assert.AreEqual(string.Empty, ConnectionStringRedactor.MaskPassword(string.Empty));
+            Assert.IsNull(ConnectionStringRedactor.MaskPassword(null!));
+        }
+
+        #endregion
+
+        #region RedactConnectionString
+
+        [TestMethod]
+        public void RedactConnectionString_SqlServer_MasksPasswordWithKeyRule()
+        {
+            string redacted = ConnectionStringRedactor.RedactConnectionString(
+                "Data Source=myserver;Initial Catalog=mydb;User ID=myuser;Password=mypass");
+
+            Assert.IsFalse(redacted.Contains("mypass"), "Full password should not appear");
+            Assert.IsTrue(redacted.Contains("mypaxx"), "Password should be masked using the key rule (first 4 chars)");
+            Assert.IsTrue(redacted.Contains("myuser"), "Non-secret values should be preserved");
+        }
+
+        [TestMethod]
+        public void RedactConnectionString_StorageAccount_MasksAccountKey()
+        {
+            string redacted = ConnectionStringRedactor.RedactConnectionString(
+                "DefaultEndpointsProtocol=https;AccountName=mystorage;AccountKey=abcdefghijklmnop;EndpointSuffix=core.windows.net");
+
+            Assert.IsFalse(redacted.Contains("abcdefghijklmnop"), "Full account key should not appear");
+            Assert.IsTrue(redacted.Contains("abcdxxxxxxxxxxxx"), "Account key should be masked using the key rule");
+            Assert.IsTrue(redacted.Contains("mystorage"), "Account name should be preserved");
+        }
+
+        [TestMethod]
+        public void RedactConnectionString_ServiceBus_MasksSharedAccessKeyButNotName()
+        {
+            string redacted = ConnectionStringRedactor.RedactConnectionString(
+                "Endpoint=sb://my.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcdefghijklmnop");
+
+            Assert.IsFalse(redacted.Contains("abcdefghijklmnop"), "Full shared access key should not appear");
+            Assert.IsTrue(redacted.Contains("abcdxxxxxxxxxxxx"), "SharedAccessKey should be masked");
+            Assert.IsTrue(redacted.Contains("RootManageSharedAccessKey"), "SharedAccessKeyName is not a secret and should be preserved");
+        }
+
+        [TestMethod]
+        public void RedactConnectionString_NullOrWhitespace_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, ConnectionStringRedactor.RedactConnectionString(null!));
+            Assert.AreEqual(string.Empty, ConnectionStringRedactor.RedactConnectionString("   "));
+        }
+
+        [TestMethod]
+        public void Redact_IsAliasForRedactConnectionString()
+        {
+            string input = "Data Source=myserver;User ID=myuser;Password=mypass";
+
+            Assert.AreEqual(
+                ConnectionStringRedactor.RedactConnectionString(input),
+                ConnectionStringRedactor.Redact(input));
+        }
+
+        #endregion
+    }
+}

--- a/src/SqlSync.Connection.UnitTest/PostgresConnectionFactoryTest.cs
+++ b/src/SqlSync.Connection.UnitTest/PostgresConnectionFactoryTest.cs
@@ -43,8 +43,8 @@ namespace SqlSync.Connection.UnitTest
             string redacted = ConnectionStringRedactor.Redact(connStr);
             var redactedBuilder = new NpgsqlConnectionStringBuilder(redacted);
 
-            Assert.IsFalse(redacted.Contains("pgpass"), "Should not contain password value");
-            Assert.AreEqual("***REDACTED***", redactedBuilder.Password, "Should retain a redacted password marker");
+            Assert.IsFalse(redacted.Contains("pgpass"), "Should not contain full password value");
+            Assert.AreEqual("pgpaxx", redactedBuilder.Password, "Password should be masked keeping the first 4 chars");
             Assert.AreEqual("pguser", redactedBuilder.Username, "Should preserve non-secret connection details");
         }
 

--- a/src/SqlSync.Connection.UnitTest/SqlServerConnectionFactoryTest.cs
+++ b/src/SqlSync.Connection.UnitTest/SqlServerConnectionFactoryTest.cs
@@ -41,8 +41,8 @@ namespace SqlSync.Connection.UnitTest
             string redacted = ConnectionStringRedactor.Redact(connStr);
             var redactedBuilder = new SqlConnectionStringBuilder(redacted);
 
-            Assert.IsFalse(redacted.Contains("mypass"), "Should not contain password value");
-            Assert.AreEqual("***REDACTED***", redactedBuilder.Password, "Should retain a redacted password marker");
+            Assert.IsFalse(redacted.Contains("mypass"), "Should not contain full password value");
+            Assert.AreEqual("mypaxx", redactedBuilder.Password, "Password should be masked keeping the first 4 chars");
             Assert.AreEqual("myuser", redactedBuilder.UserID, "Should preserve non-secret connection details");
         }
 
@@ -52,7 +52,7 @@ namespace SqlSync.Connection.UnitTest
             string connStr = factory.BuildConnectionString("mydb", "myserver", "", "", AuthenticationType.Windows, 30, "");
 
             Assert.IsTrue(connStr.Contains("Integrated Security=True"), "Should set Integrated Security");
-            Assert.IsTrue(connStr.Contains("Trust Server Certificate=True"), "Should trust server cert");
+            Assert.IsFalse(connStr.Contains("Trust Server Certificate=True"), "Should NOT trust server cert by default (secure-by-default)");
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace SqlSync.Connection.UnitTest
             string connStr = factory.BuildConnectionString("mydb", "myserver", "", "", AuthenticationType.AzureADDefault, 30, "");
 
             Assert.IsTrue(connStr.Contains("Authentication=ActiveDirectoryDefault"), "Should set AD Default auth");
-            Assert.IsTrue(connStr.Contains("Trust Server Certificate=True"), "Should trust server cert");
+            Assert.IsFalse(connStr.Contains("Trust Server Certificate=True"), "Should NOT trust server cert by default (secure-by-default)");
         }
 
         [TestMethod]
@@ -161,6 +161,103 @@ namespace SqlSync.Connection.UnitTest
             Assert.IsTrue(connStr.Contains("Data Source=sqlserver1"), "Should use server from ConnectionData");
             Assert.IsTrue(connStr.Contains("Initial Catalog=testdb"), "Should use database from ConnectionData");
             Assert.IsTrue(connStr.Contains("Connect Timeout=45"), "Should use timeout from ConnectionData");
+        }
+
+        #endregion
+
+        #region TrustServerCertificate (TLS) Tests
+
+        [TestMethod]
+        public void BuildConnectionString_PasswordAuth_DefaultsToNoTrust()
+        {
+            string connStr = factory.BuildConnectionString("mydb", "myserver", "u", "p", AuthenticationType.Password, 30, "");
+
+            var builder = new SqlConnectionStringBuilder(connStr);
+            Assert.IsFalse(builder.TrustServerCertificate, "Default (7-arg) overload must NOT trust the server certificate");
+        }
+
+        [TestMethod]
+        public void BuildConnectionString_PasswordAuth_TrustOptIn_SetsTrustTrue()
+        {
+            string connStr = factory.BuildConnectionString("mydb", "myserver", "u", "p", AuthenticationType.Password, 30, "", true);
+
+            var builder = new SqlConnectionStringBuilder(connStr);
+            Assert.IsTrue(builder.TrustServerCertificate, "Opt-in (8-arg) overload must trust the server certificate when requested");
+        }
+
+        [TestMethod]
+        public void BuildConnectionString_WindowsAuth_TrustOptIn_SetsTrustTrue()
+        {
+            string connStr = factory.BuildConnectionString("mydb", "myserver", "", "", AuthenticationType.Windows, 30, "", true);
+
+            var builder = new SqlConnectionStringBuilder(connStr);
+            Assert.IsTrue(builder.TrustServerCertificate, "Windows auth should honor the trust opt-in");
+        }
+
+        [TestMethod]
+        public void BuildConnectionString_FromConnectionData_HonorsTrustServerCertificate()
+        {
+            var connData = new ConnectionData
+            {
+                DatabaseName = "testdb",
+                SQLServerName = "sqlserver1",
+                UserId = "user1",
+                Password = "pass1",
+                AuthenticationType = AuthenticationType.Password,
+                ScriptTimeout = 45,
+                TrustServerCertificate = true
+            };
+
+            var builder = new SqlConnectionStringBuilder(factory.BuildConnectionString(connData));
+            Assert.IsTrue(builder.TrustServerCertificate, "ConnectionData.TrustServerCertificate should flow into the connection string");
+        }
+
+        [TestMethod]
+        public void BuildConnectionString_FromConnectionData_DefaultsToNoTrust()
+        {
+            var connData = new ConnectionData
+            {
+                DatabaseName = "testdb",
+                SQLServerName = "sqlserver1",
+                UserId = "user1",
+                Password = "pass1",
+                AuthenticationType = AuthenticationType.Password,
+                ScriptTimeout = 45
+            };
+
+            var builder = new SqlConnectionStringBuilder(factory.BuildConnectionString(connData));
+            Assert.IsFalse(builder.TrustServerCertificate, "ConnectionData defaults to NOT trusting the server certificate");
+        }
+
+        [TestMethod]
+        public void Postgres_BuildConnectionString_IgnoresTrustServerCertificate()
+        {
+            var pgFactory = new PostgresConnectionFactory();
+            string withTrust = pgFactory.BuildConnectionString("db", "srv", "u", "p", AuthenticationType.Password, 30, "", true);
+            string withoutTrust = pgFactory.BuildConnectionString("db", "srv", "u", "p", AuthenticationType.Password, 30, "");
+
+            Assert.AreEqual(withoutTrust, withTrust, "PostgreSQL uses SslMode and must ignore the TrustServerCertificate flag");
+            Assert.IsFalse(withTrust.Contains("Trust Server Certificate"), "PostgreSQL connection string should not contain TrustServerCertificate");
+        }
+
+        [TestMethod]
+        public void BuildConnectionString_AmbientDefault_AppliesToFieldOverloads()
+        {
+            // The process-wide ambient default lets the operator opt in once (e.g. via
+            // --trustservercertificate) so helper paths that rebuild connections from individual
+            // fields honor that choice even though they don't carry a ConnectionData.
+            bool original = ConnectionHelper.TrustServerCertificate;
+            try
+            {
+                ConnectionHelper.TrustServerCertificate = true;
+                var builder = new SqlConnectionStringBuilder(
+                    factory.BuildConnectionString("mydb", "myserver", "u", "p", AuthenticationType.Password, 30, ""));
+                Assert.IsTrue(builder.TrustServerCertificate, "Field-based overload should honor the ambient ConnectionHelper.TrustServerCertificate default");
+            }
+            finally
+            {
+                ConnectionHelper.TrustServerCertificate = original;
+            }
         }
 
         #endregion

--- a/src/SqlSync.Connection/ConnectionData.cs
+++ b/src/SqlSync.Connection/ConnectionData.cs
@@ -20,6 +20,8 @@ namespace SqlSync.Connection
 
         private string _ManagedIdentityClientId = string.Empty;
 
+        private bool _TrustServerCertificate = false;
+
         private AuthenticationType authType = AuthenticationType.Password;
 
         private DatabasePlatform _DatabasePlatform = DatabasePlatform.SqlServer;
@@ -146,6 +148,22 @@ namespace SqlSync.Connection
             }
         }
 
+        /// <summary>
+        /// When true, the SQL Server TLS certificate is trusted without validation (TrustServerCertificate=true).
+        /// Defaults to false (secure): the server certificate is validated. SQL Server only; ignored for PostgreSQL.
+        /// </summary>
+        public virtual bool TrustServerCertificate
+        {
+            get
+            {
+                return _TrustServerCertificate;
+            }
+            set
+            {
+                _TrustServerCertificate = value;
+            }
+        }
+
         public virtual ConnectionData Fill(ConnectionData dataClass)
         {
             try
@@ -159,6 +177,7 @@ namespace SqlSync.Connection
                 ScriptTimeout = dataClass.ScriptTimeout;
                 ManagedIdentityClientId = dataClass.ManagedIdentityClientId;
                 _DatabasePlatform = dataClass._DatabasePlatform;
+                _TrustServerCertificate = dataClass._TrustServerCertificate;
                 return this;
             }
             catch (System.Exception ex)

--- a/src/SqlSync.Connection/ConnectionHelper.cs
+++ b/src/SqlSync.Connection/ConnectionHelper.cs
@@ -20,6 +20,16 @@ namespace SqlSync.Connection
 
         private static ILogger log = SqlBuildManager.Logging.ApplicationLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod()!.DeclaringType!);
         public static string appName = "Sql Build Manager v{0} [{1}];";
+
+        /// <summary>
+        /// Process-wide opt-in for trusting (not validating) the SQL Server TLS certificate.
+        /// Secure-by-default (false): certificates are validated. The operator opts in once at
+        /// startup via the <c>--trustservercertificate</c> flag (or settings file), which is seeded
+        /// here so that connection-string overloads that don't carry a <see cref="ConnectionData"/>
+        /// still honor the operator's run-level choice. Connection-data based overloads OR this with
+        /// the per-connection <see cref="ConnectionData.TrustServerCertificate"/> value.
+        /// </summary>
+        public static bool TrustServerCertificate { get; set; } = false;
         static ConnectionHelper()
         {
             string version;
@@ -74,13 +84,7 @@ namespace SqlSync.Connection
             if (connData == null)
                 return null!;
 
-            return GetConnection(connData.DatabaseName,
-                connData.SQLServerName,
-                connData.UserId,
-                connData.Password,
-                connData.AuthenticationType,
-                connData.ScriptTimeout,
-                connData.ManagedIdentityClientId);
+            return new SqlConnection(GetConnectionString(connData));
         }
         public static string GetConnectionString(ConnectionData connData)
         {
@@ -93,9 +97,14 @@ namespace SqlSync.Connection
                 connData.Password,
                 connData.AuthenticationType,
                 connData.ScriptTimeout,
-                connData.ManagedIdentityClientId);
+                connData.ManagedIdentityClientId,
+                connData.TrustServerCertificate || TrustServerCertificate);
         }
         public static string GetConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId)
+        {
+            return GetConnectionString(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId, TrustServerCertificate);
+        }
+        public static string GetConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
         {
             SqlServerAuthenticationProvider.Register();
 
@@ -113,18 +122,18 @@ namespace SqlSync.Connection
             {
                 case AuthenticationType.Windows:
                     builder.IntegratedSecurity = true;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADIntegrated:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryIntegrated;
                     builder.IntegratedSecurity = true;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADDefault:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryDefault;
                     if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
                         builder.UserID = managedIdentityClientId;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADPassword:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryPassword;
@@ -143,10 +152,10 @@ namespace SqlSync.Connection
                     builder.Authentication = SqlAuthenticationMethod.SqlPassword;
                     builder.UserID = uid;
                     builder.Password = pw;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
             }
-            log.LogDebug($"Database Connection string: {builder.ConnectionString}");
+            log.LogDebug($"Database Connection string: {ConnectionStringRedactor.Redact(builder.ConnectionString)}");
             return builder.ConnectionString;
         }
 
@@ -184,6 +193,10 @@ namespace SqlSync.Connection
 
         public static bool TestDatabaseConnection(string dbName, string serverName, string username, string password, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId)
         {
+            return TestDatabaseConnection(dbName, serverName, username, password, authType, scriptTimeOut, managedIdentityClientId, TrustServerCertificate);
+        }
+        public static bool TestDatabaseConnection(string dbName, string serverName, string username, string password, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
+        {
             return TestDatabaseConnection(new ConnectionData()
             {
                 DatabaseName = dbName,
@@ -192,7 +205,8 @@ namespace SqlSync.Connection
                 UserId = username,
                 Password = password,
                 AuthenticationType = authType,
-                ManagedIdentityClientId = managedIdentityClientId                
+                ManagedIdentityClientId = managedIdentityClientId,
+                TrustServerCertificate = trustServerCertificate
             });
         }
         public static bool TestDatabaseConnection(ConnectionData connData)

--- a/src/SqlSync.Connection/ConnectionStringRedactor.cs
+++ b/src/SqlSync.Connection/ConnectionStringRedactor.cs
@@ -5,19 +5,72 @@ using System.Linq;
 
 namespace SqlSync.Connection
 {
-    internal static class ConnectionStringRedactor
+    /// <summary>
+    /// Centralized helper for masking secrets before they are written to logs or other diagnostic output.
+    /// Masking is partial so an operator can still visually validate which credential is in use without
+    /// the full secret being exposed in logs:
+    ///  - <see cref="MaskKey"/> (storage/account/shared-access keys): keep the first 4 characters,
+    ///    replace the remainder with lowercase 'x'.
+    ///  - <see cref="MaskPassword"/> (passwords): keep the first and last character, replace the middle
+    ///    with lowercase 'x'.
+    ///  - <see cref="RedactConnectionString"/>: mask each embedded sensitive value using the key rule
+    ///    (first 4 characters preserved, remainder lowercase 'x'). Works for SQL, Storage, Service Bus
+    ///    and Event Hub style connection strings.
+    /// </summary>
+    public static class ConnectionStringRedactor
     {
-        private const string RedactedValue = "***REDACTED***";
-
         private static readonly HashSet<string> SensitiveKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Password",
             "Pwd",
             "Access Token",
-            "Token"
+            "Token",
+            "SharedAccessKey",
+            "AccountKey",
+            "SharedAccessSignature"
         };
 
-        public static string Redact(string connectionString)
+        /// <summary>
+        /// Masks a key/secret value, preserving the first 4 characters so an operator can visually verify
+        /// which key is in use. The remainder is replaced with lowercase 'x'. Values of 4 characters or
+        /// fewer are fully masked.
+        /// </summary>
+        public static string MaskKey(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+            if (value.Length <= 4)
+            {
+                return new string('x', value.Length);
+            }
+            return value.Substring(0, 4) + new string('x', value.Length - 4);
+        }
+
+        /// <summary>
+        /// Masks a password, preserving the first and last character with the middle replaced by lowercase
+        /// 'x'. Values of 2 characters or fewer are fully masked.
+        /// </summary>
+        public static string MaskPassword(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+            if (value.Length <= 2)
+            {
+                return new string('x', value.Length);
+            }
+            return value[0] + new string('x', value.Length - 2) + value[value.Length - 1];
+        }
+
+        /// <summary>
+        /// Redacts sensitive values embedded in a connection string. Each sensitive value is masked using
+        /// the key rule (first 4 characters preserved, remainder lowercase 'x'). If the connection string
+        /// cannot be parsed it is masked in its entirety so a raw secret is never emitted.
+        /// </summary>
+        public static string RedactConnectionString(string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -33,22 +86,29 @@ namespace SqlSync.Connection
 
                 foreach (string key in builder.Keys.Cast<string>().Where(IsSensitiveKey).ToList())
                 {
-                    builder[key] = RedactedValue;
+                    builder[key] = MaskKey(builder[key]?.ToString() ?? string.Empty);
                 }
 
                 return builder.ConnectionString;
             }
             catch (ArgumentException)
             {
-                return RedactedValue;
+                return MaskKey(connectionString);
             }
         }
+
+        /// <summary>
+        /// Backward-compatible alias for <see cref="RedactConnectionString"/>.
+        /// </summary>
+        public static string Redact(string connectionString) => RedactConnectionString(connectionString);
 
         private static bool IsSensitiveKey(string key)
         {
             return SensitiveKeys.Contains(key)
                 || key.EndsWith("Password", StringComparison.OrdinalIgnoreCase)
-                || key.EndsWith("Token", StringComparison.OrdinalIgnoreCase);
+                || key.EndsWith("Token", StringComparison.OrdinalIgnoreCase)
+                || key.EndsWith("AccountKey", StringComparison.OrdinalIgnoreCase)
+                || key.EndsWith("AccessKey", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/SqlSync.Connection/IDbConnectionFactory.cs
+++ b/src/SqlSync.Connection/IDbConnectionFactory.cs
@@ -10,8 +10,10 @@ namespace SqlSync.Connection
     {
         DbConnection CreateConnection(ConnectionData connData);
         DbConnection CreateConnection(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId);
+        DbConnection CreateConnection(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate);
         string BuildConnectionString(ConnectionData connData);
         string BuildConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId);
+        string BuildConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate);
         DbCommand CreateCommand(string sql, DbConnection connection, DbTransaction transaction = null!);
         DbParameter CreateParameter(string name, object value);
     }

--- a/src/SqlSync.Connection/PostgresConnectionFactory.cs
+++ b/src/SqlSync.Connection/PostgresConnectionFactory.cs
@@ -31,6 +31,12 @@ namespace SqlSync.Connection
             return new NpgsqlConnection(conn);
         }
 
+        // PostgreSQL uses SslMode (not TrustServerCertificate); the flag is accepted for interface parity and ignored.
+        public DbConnection CreateConnection(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
+        {
+            return CreateConnection(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId);
+        }
+
         public string BuildConnectionString(ConnectionData connData)
         {
             return BuildConnectionString(connData.DatabaseName, connData.SQLServerName, connData.UserId, connData.Password,
@@ -93,6 +99,12 @@ namespace SqlSync.Connection
 
             log.LogDebug($"PostgreSQL Connection string: {ConnectionStringRedactor.Redact(builder.ConnectionString)}");
             return builder.ConnectionString;
+        }
+
+        // PostgreSQL uses SslMode (not TrustServerCertificate); the flag is accepted for interface parity and ignored.
+        public string BuildConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
+        {
+            return BuildConnectionString(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId);
         }
 
         /// <summary>

--- a/src/SqlSync.Connection/SqlServerConnectionFactory.cs
+++ b/src/SqlSync.Connection/SqlServerConnectionFactory.cs
@@ -14,23 +14,33 @@ namespace SqlSync.Connection
         public DbConnection CreateConnection(ConnectionData connData)
         {
             return CreateConnection(connData.DatabaseName, connData.SQLServerName, connData.UserId, connData.Password,
-                connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId);
+                connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId, connData.TrustServerCertificate || ConnectionHelper.TrustServerCertificate);
         }
 
         public DbConnection CreateConnection(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId)
         {
+            return CreateConnection(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId, ConnectionHelper.TrustServerCertificate);
+        }
+
+        public DbConnection CreateConnection(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
+        {
             SqlServerAuthenticationProvider.Register();
-            string conn = BuildConnectionString(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId);
+            string conn = BuildConnectionString(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId, trustServerCertificate);
             return new SqlConnection(conn);
         }
 
         public string BuildConnectionString(ConnectionData connData)
         {
             return BuildConnectionString(connData.DatabaseName, connData.SQLServerName, connData.UserId, connData.Password,
-                connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId);
+                connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId, connData.TrustServerCertificate || ConnectionHelper.TrustServerCertificate);
         }
 
         public string BuildConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId)
+        {
+            return BuildConnectionString(dbName, serverName, uid, pw, authType, scriptTimeOut, managedIdentityClientId, ConnectionHelper.TrustServerCertificate);
+        }
+
+        public string BuildConnectionString(string dbName, string serverName, string uid, string pw, AuthenticationType authType, int scriptTimeOut, string managedIdentityClientId, bool trustServerCertificate)
         {
             var builder = new SqlConnectionStringBuilder();
             builder.DataSource = serverName;
@@ -45,18 +55,18 @@ namespace SqlSync.Connection
             {
                 case AuthenticationType.Windows:
                     builder.IntegratedSecurity = true;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADIntegrated:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryIntegrated;
                     builder.IntegratedSecurity = true;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADDefault:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryDefault;
                     if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
                         builder.UserID = managedIdentityClientId;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
                 case AuthenticationType.AzureADPassword:
                     builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryPassword;
@@ -75,7 +85,7 @@ namespace SqlSync.Connection
                     builder.Authentication = SqlAuthenticationMethod.SqlPassword;
                     builder.UserID = uid;
                     builder.Password = pw;
-                    builder.TrustServerCertificate = true;
+                    builder.TrustServerCertificate = trustServerCertificate;
                     break;
             }
             log.LogDebug($"Database Connection string: {ConnectionStringRedactor.Redact(builder.ConnectionString)}");

--- a/src/SqlSync.SqlBuild.Dependent.UnitTest/AssemblyInit.cs
+++ b/src/SqlSync.SqlBuild.Dependent.UnitTest/AssemblyInit.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlSync.Connection;
+
+namespace SqlSync.SqlBuild.Dependent.UnitTest
+{
+    /// <summary>
+    /// Assembly-wide test setup. The dependent tests run against a local SQL Express instance
+    /// using a self-signed certificate. Production seeds <see cref="ConnectionHelper.TrustServerCertificate"/>
+    /// from the operator's <c>--trustservercertificate</c> choice at command startup; the tests
+    /// mirror that opt-in here so connection paths that rebuild connections from individual fields
+    /// (rather than carrying a <see cref="ConnectionData"/>) can connect.
+    /// </summary>
+    [TestClass]
+    public static class AssemblyInit
+    {
+        [AssemblyInitialize]
+        public static void AssemblyInitialize(TestContext context)
+        {
+            ConnectionHelper.TrustServerCertificate = true;
+        }
+    }
+}

--- a/src/SqlSync.SqlBuild.Dependent.UnitTest/Initialization.cs
+++ b/src/SqlSync.SqlBuild.Dependent.UnitTest/Initialization.cs
@@ -78,6 +78,7 @@ namespace SqlSync.SqlBuild.Dependent.UnitTest
             testDatabaseNames.Add("SqlBuildTest_SyncTest3");
 
             connData = new ConnectionData(serverName, testDatabaseNames[0]);
+            connData.TrustServerCertificate = true;
             var sqlUser = Environment.GetEnvironmentVariable("SBM_TEST_SQL_USER");
             var sqlPassword = Environment.GetEnvironmentVariable("SBM_TEST_SQL_PASSWORD");
             if (!string.IsNullOrWhiteSpace(sqlUser))
@@ -325,6 +326,7 @@ namespace SqlSync.SqlBuild.Dependent.UnitTest
             cd.AuthenticationType = connData.AuthenticationType;
             cd.UserId = connData.UserId;
             cd.Password = connData.Password;
+            cd.TrustServerCertificate = connData.TrustServerCertificate;
             return cd;
         }
 

--- a/src/SqlSync.SqlBuild.UnitTest/Utilities/CryptographyTests.cs
+++ b/src/SqlSync.SqlBuild.UnitTest/Utilities/CryptographyTests.cs
@@ -53,7 +53,7 @@ namespace SqlSync.SqlBuild.UnitTest.Utilities
         }
 
         [TestMethod]
-        public void EncryptText_SameInputSamePassword_ProducesSameOutput()
+        public void EncryptText_SameInputSamePassword_ProducesDifferentOutput()
         {
             // Arrange
             string original = "Consistent encryption test";
@@ -62,8 +62,49 @@ namespace SqlSync.SqlBuild.UnitTest.Utilities
             string encrypted1 = Cryptography.EncryptText(original, TestPassword);
             string encrypted2 = Cryptography.EncryptText(original, TestPassword);
 
+            // Assert — v1 uses a random salt+IV per call, so ciphertext must NOT be deterministic.
+            Assert.AreNotEqual(encrypted1, encrypted2, "v1 encryption must be non-deterministic (random salt/IV)");
+
+            // ...but both must still decrypt back to the original.
+            var (s1, d1) = Cryptography.DecryptText(encrypted1, TestPassword, "t", true);
+            var (s2, d2) = Cryptography.DecryptText(encrypted2, TestPassword, "t", true);
+            Assert.IsTrue(s1 && s2);
+            Assert.AreEqual(original, d1);
+            Assert.AreEqual(original, d2);
+        }
+
+        [TestMethod]
+        public void DecryptText_LegacyFormat_StillDecrypts()
+        {
+            // Arrange — produced by the OLD algorithm (AES-256-CBC, PBKDF2-SHA1/1000, static salt)
+            // for plaintext "Legacy secret value" with password TestPassword. Backward compatibility
+            // requires existing settings files like this to remain readable.
+            const string legacyEncrypted = "kWjkYZD2mej9lJ6YltINXQMS09IP2575k2b2NtK6P60=";
+
+            // Act
+            var (success, decrypted) = Cryptography.DecryptText(legacyEncrypted, TestPassword, "legacy value", true);
+
             // Assert
-            Assert.AreEqual(encrypted1, encrypted2);
+            Assert.IsTrue(success, "Legacy-encrypted values must still decrypt");
+            Assert.AreEqual("Legacy secret value", decrypted);
+        }
+
+        [TestMethod]
+        public void DecryptText_TamperedV1Ciphertext_ReturnsFalse()
+        {
+            // Arrange
+            string encrypted = Cryptography.EncryptText("Authenticated secret", TestPassword);
+            byte[] raw = Convert.FromBase64String(encrypted);
+            // Flip a bit in the ciphertext region (after the 33-byte header, before the 32-byte HMAC).
+            raw[40] ^= 0xFF;
+            string tampered = Convert.ToBase64String(raw);
+
+            // Act
+            var (success, result) = Cryptography.DecryptText(tampered, TestPassword, "tampered", true);
+
+            // Assert — HMAC verification must reject the tampered payload.
+            Assert.IsFalse(success);
+            Assert.AreEqual(tampered, result);
         }
 
         [TestMethod]

--- a/src/SqlSync.SqlBuild.UnitTest/Utilities/UtilitiesFinalTests.cs
+++ b/src/SqlSync.SqlBuild.UnitTest/Utilities/UtilitiesFinalTests.cs
@@ -231,7 +231,7 @@ namespace SqlSync.SqlBuild.UnitTest.Utilities
         }
 
         [TestMethod]
-        public void EncryptText_SameInputProducesSameOutput()
+        public void EncryptText_SameInputProducesDifferentOutput()
         {
             // Arrange
             string input = "Hello World";
@@ -241,8 +241,13 @@ namespace SqlSync.SqlBuild.UnitTest.Utilities
             var encrypted1 = Cryptography.EncryptText(input, password);
             var encrypted2 = Cryptography.EncryptText(input, password);
 
-            // Assert
-            Assert.AreEqual(encrypted1, encrypted2);
+            // Assert — v1 encryption is non-deterministic (random salt/IV); both still round-trip.
+            Assert.AreNotEqual(encrypted1, encrypted2);
+            var (s1, d1) = Cryptography.DecryptText(encrypted1, password, "t", true);
+            var (s2, d2) = Cryptography.DecryptText(encrypted2, password, "t", true);
+            Assert.IsTrue(s1 && s2);
+            Assert.AreEqual(input, d1);
+            Assert.AreEqual(input, d2);
         }
 
         [TestMethod]

--- a/src/SqlSync.SqlBuild/AdHocQuery/QueryCollectionRunner.cs
+++ b/src/SqlSync.SqlBuild/AdHocQuery/QueryCollectionRunner.cs
@@ -88,6 +88,7 @@ namespace SqlSync.SqlBuild.AdHocQuery
                 connData.ScriptTimeout = scriptTimeout;
                 connData.DatabasePlatform = masterConnData.DatabasePlatform;
                 connData.ManagedIdentityClientId = masterConnData.ManagedIdentityClientId;
+                connData.TrustServerCertificate = masterConnData.TrustServerCertificate;
                 DbConnection conn = ConnectionHelper.GetDbConnection(connData);
                 DbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = query;

--- a/src/SqlSync.SqlBuild/Services/DefaultConnectionsService.cs
+++ b/src/SqlSync.SqlBuild/Services/DefaultConnectionsService.cs
@@ -107,7 +107,7 @@ namespace SqlSync.SqlBuild.Services
                 if (Connections.ContainsKey(databaseKey) == false)
                 {
                     BuildConnectData cData = new BuildConnectData();
-                    cData.Connection = _connectionFactory.CreateConnection(databaseName, serverName, connData.UserId, connData.Password, connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId);
+                    cData.Connection = _connectionFactory.CreateConnection(databaseName, serverName, connData.UserId, connData.Password, connData.AuthenticationType, connData.ScriptTimeout, connData.ManagedIdentityClientId, connData.TrustServerCertificate || ConnectionHelper.TrustServerCertificate);
                     cData = PrepConnectionAndTransaction(cData, isTransactional);
                     cData.DatabaseName = databaseName;
                     cData.ServerName = serverName;

--- a/src/SqlSync.SqlBuild/Utilities/Cryptography.cs
+++ b/src/SqlSync.SqlBuild/Utilities/Cryptography.cs
@@ -7,27 +7,46 @@ namespace SqlSync.SqlBuild.Utilities
 {
 
     /// <summary>
-    /// http://www.codeproject.com/Articles/769741/Csharp-AES-bits-Encryption-Library-with-Salt
+    /// AES-256 encryption helper for settings-file secrets.
+    ///
+    /// Format v1 (current): authenticated encryption. The base64 payload is laid out as
+    ///   [version(1)][salt(16)][iv(16)][ciphertext(n*16)][hmac(32)]
+    /// A random salt and IV are generated per call (output is non-deterministic). A 64-byte key
+    /// is derived with PBKDF2-SHA256 (100,000 iterations); the first 32 bytes are the AES key and
+    /// the next 32 bytes are the HMAC-SHA256 key. The HMAC covers version||salt||iv||ciphertext and
+    /// is verified (constant-time) before decryption, so a wrong password fails deterministically.
+    ///
+    /// Legacy format (read-only, for backward compatibility): raw AES-256-CBC ciphertext whose key
+    /// and IV were both derived with PBKDF2-SHA1 (1,000 iterations) from a static salt. Existing
+    /// encrypted settings files remain readable; they are upgraded to v1 the next time the value is
+    /// saved (callers re-encrypt via <see cref="EncryptText"/>).
     /// </summary>
     public static class Cryptography
     {
         private static ILogger log = SqlBuildManager.Logging.ApplicationLogging.CreateLogger(System.Reflection.MethodBase.GetCurrentMethod()!.DeclaringType!);
+
+        private const byte FormatVersion1 = 0x01;
+        private const int SaltSize = 16;
+        private const int IvSize = 16;
+        private const int HmacSize = 32;
+        private const int Pbkdf2Iterations = 100_000;
+        // Header = version + salt + iv; trailer = hmac. Ciphertext is a non-zero multiple of the AES block size.
+        private const int HeaderSize = 1 + SaltSize + IvSize;
+        private const int MinV1Length = HeaderSize + 16 + HmacSize; // 1 + 16 + 16 + 16 + 32 = 81
+
         public static string EncryptText(string input, string password)
         {
             try
             {
-                // Get the bytes of the string
                 byte[] bytesToBeEncrypted = Encoding.UTF8.GetBytes(input);
-                byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
 
-                // Hash the password with SHA256
-                passwordBytes = SHA256.Create().ComputeHash(passwordBytes);
+                // Preserve legacy password normalization (SHA256 of the password) so the same
+                // password works across legacy and v1 payloads.
+                byte[] passwordBytes = SHA256.HashData(Encoding.UTF8.GetBytes(password));
 
-                byte[] bytesEncrypted = AES_Encrypt(bytesToBeEncrypted, passwordBytes);
+                byte[] bytesEncrypted = AES_Encrypt_V1(bytesToBeEncrypted, passwordBytes);
 
-                string result = Convert.ToBase64String(bytesEncrypted);
-
-                return result;
+                return Convert.ToBase64String(bytesEncrypted);
             }
             catch
             {
@@ -39,20 +58,28 @@ namespace SqlSync.SqlBuild.Utilities
         {
             try
             {
-                if(string.IsNullOrWhiteSpace(input) || string.IsNullOrWhiteSpace(password))
+                if (string.IsNullOrWhiteSpace(input) || string.IsNullOrWhiteSpace(password))
                 {
-                    return(true, input);
+                    return (true, input);
                 }
 
-                // Get the bytes of the string
                 byte[] bytesToBeDecrypted = Convert.FromBase64String(input);
-                byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
-                passwordBytes = SHA256.Create().ComputeHash(passwordBytes);
+                byte[] passwordBytes = SHA256.HashData(Encoding.UTF8.GetBytes(password));
 
-                byte[] bytesDecrypted = AES_Decrypt(bytesToBeDecrypted, passwordBytes);
+                byte[] bytesDecrypted;
+                if (IsV1Format(bytesToBeDecrypted))
+                {
+                    // Structurally a v1 payload: only the v1 path can succeed. Never fall back to
+                    // legacy (a v1 length can never be mistaken for legacy), so a failed HMAC/decrypt
+                    // is a genuine wrong-password/corruption and must report failure.
+                    bytesDecrypted = AES_Decrypt_V1(bytesToBeDecrypted, passwordBytes);
+                }
+                else
+                {
+                    bytesDecrypted = AES_Decrypt_Legacy(bytesToBeDecrypted, passwordBytes);
+                }
 
                 string result = Encoding.UTF8.GetString(bytesDecrypted);
-
                 return (true, result);
             }
             catch (Exception)
@@ -65,66 +92,134 @@ namespace SqlSync.SqlBuild.Utilities
             }
         }
 
-        private static byte[] saltBytes = new byte[] { 84, 104, 105, 115, 73, 115, 83, 113, 108, 66, 117, 105, 108, 100, 77, 97, 110, 97, 103, 101, 114, 66, 121, 116, 101, 73, 110, 105, 116, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110 };
-
-        private static byte[] AES_Encrypt(byte[] bytesToBeEncrypted, byte[] passwordBytes)
+        /// <summary>
+        /// A payload is v1 only if it carries the version marker and its length matches the
+        /// fixed-overhead layout. Legacy ciphertext length is always a multiple of 16, while a v1
+        /// length is always (16k + 1), so the two are mutually exclusive — no ambiguity.
+        /// </summary>
+        private static bool IsV1Format(byte[] data)
         {
-            byte[] encryptedBytes = null!;
-            using (MemoryStream ms = new MemoryStream())
-            {
-                using (var AES = Aes.Create())
-                {
-                    AES.KeySize = 256;
-                    AES.BlockSize = 128;
-
-                    // var key = new Rfc2898DeriveBytes(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1);
-                    // AES.Key = key.GetBytes(AES.KeySize / 8);
-                    // AES.IV = key.GetBytes(AES.BlockSize / 8);
-
-                    AES.Key= Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1, AES.KeySize / 8);
-                    AES.IV = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1,AES.BlockSize / 8);
-
-                    AES.Mode = CipherMode.CBC;
-
-                    using (var cs = new CryptoStream(ms, AES.CreateEncryptor(), CryptoStreamMode.Write))
-                    {
-                        cs.Write(bytesToBeEncrypted, 0, bytesToBeEncrypted.Length);
-                        cs.Close();
-                    }
-                    encryptedBytes = ms.ToArray();
-                }
-            }
-
-            return encryptedBytes;
+            return data.Length >= MinV1Length
+                && data[0] == FormatVersion1
+                && (data.Length - HeaderSize - HmacSize) % 16 == 0;
         }
 
-        private static byte[] AES_Decrypt(byte[] bytesToBeDecrypted, byte[] passwordBytes)
+        // Legacy static salt — required to read settings files encrypted by older versions. Do NOT use for new encryption.
+        private static byte[] saltBytes = new byte[] { 84, 104, 105, 115, 73, 115, 83, 113, 108, 66, 117, 105, 108, 100, 77, 97, 110, 97, 103, 101, 114, 66, 121, 116, 101, 73, 110, 105, 116, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110 };
+
+        private static byte[] AES_Encrypt_V1(byte[] bytesToBeEncrypted, byte[] passwordBytes)
         {
-            byte[] decryptedBytes = null!;
+            byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
+            byte[] iv = RandomNumberGenerator.GetBytes(IvSize);
 
-            using (MemoryStream ms = new MemoryStream())
+            // Derive 64 bytes: [0..32) AES key, [32..64) HMAC key.
+            byte[] keyMaterial = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, salt, Pbkdf2Iterations, HashAlgorithmName.SHA256, 64);
+            byte[] encKey = new byte[32];
+            byte[] macKey = new byte[32];
+            Buffer.BlockCopy(keyMaterial, 0, encKey, 0, 32);
+            Buffer.BlockCopy(keyMaterial, 32, macKey, 0, 32);
+
+            byte[] cipherText;
+            using (var aes = Aes.Create())
             {
-                using (var AES = Aes.Create())
+                aes.KeySize = 256;
+                aes.BlockSize = 128;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                aes.Key = encKey;
+                aes.IV = iv;
+
+                using var ms = new MemoryStream();
+                using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
                 {
-                    AES.KeySize = 256;
-                    AES.BlockSize = 128;
-
-                    // var key = new Rfc2898DeriveBytes(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1);
-                    // AES.Key = key.GetBytes(AES.KeySize / 8);
-                    // AES.IV = key.GetBytes(AES.BlockSize / 8);
-
-                    AES.Key= Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1, AES.KeySize / 8);
-                    AES.IV = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1,AES.BlockSize / 8);
-
-                    AES.Mode = CipherMode.CBC;
-
-                    using (var cs = new CryptoStream(ms, AES.CreateDecryptor(), CryptoStreamMode.Write))
-                    {
-                        cs.Write(bytesToBeDecrypted, 0, bytesToBeDecrypted.Length);
-                        cs.Close();
-                    }
-                    decryptedBytes = ms.ToArray();
+                    cs.Write(bytesToBeEncrypted, 0, bytesToBeEncrypted.Length);
+                    cs.FlushFinalBlock();
                 }
+                cipherText = ms.ToArray();
+            }
+
+            // Encrypt-then-MAC over version || salt || iv || ciphertext.
+            byte[] macInput = new byte[HeaderSize + cipherText.Length];
+            macInput[0] = FormatVersion1;
+            Buffer.BlockCopy(salt, 0, macInput, 1, SaltSize);
+            Buffer.BlockCopy(iv, 0, macInput, 1 + SaltSize, IvSize);
+            Buffer.BlockCopy(cipherText, 0, macInput, HeaderSize, cipherText.Length);
+
+            byte[] mac = HMACSHA256.HashData(macKey, macInput);
+
+            byte[] output = new byte[macInput.Length + HmacSize];
+            Buffer.BlockCopy(macInput, 0, output, 0, macInput.Length);
+            Buffer.BlockCopy(mac, 0, output, macInput.Length, HmacSize);
+            return output;
+        }
+
+        private static byte[] AES_Decrypt_V1(byte[] data, byte[] passwordBytes)
+        {
+            byte[] salt = new byte[SaltSize];
+            byte[] iv = new byte[IvSize];
+            Buffer.BlockCopy(data, 1, salt, 0, SaltSize);
+            Buffer.BlockCopy(data, 1 + SaltSize, iv, 0, IvSize);
+
+            int cipherLen = data.Length - HeaderSize - HmacSize;
+            byte[] cipherText = new byte[cipherLen];
+            Buffer.BlockCopy(data, HeaderSize, cipherText, 0, cipherLen);
+
+            byte[] storedMac = new byte[HmacSize];
+            Buffer.BlockCopy(data, HeaderSize + cipherLen, storedMac, 0, HmacSize);
+
+            byte[] keyMaterial = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, salt, Pbkdf2Iterations, HashAlgorithmName.SHA256, 64);
+            byte[] encKey = new byte[32];
+            byte[] macKey = new byte[32];
+            Buffer.BlockCopy(keyMaterial, 0, encKey, 0, 32);
+            Buffer.BlockCopy(keyMaterial, 32, macKey, 0, 32);
+
+            // Verify the MAC (constant-time) before decrypting. A wrong password fails here deterministically.
+            byte[] macInput = new byte[HeaderSize + cipherLen];
+            Buffer.BlockCopy(data, 0, macInput, 0, HeaderSize + cipherLen);
+            byte[] computedMac = HMACSHA256.HashData(macKey, macInput);
+            if (!CryptographicOperations.FixedTimeEquals(computedMac, storedMac))
+            {
+                throw new CryptographicException("Authentication tag mismatch.");
+            }
+
+            using var aes = Aes.Create();
+            aes.KeySize = 256;
+            aes.BlockSize = 128;
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+            aes.Key = encKey;
+            aes.IV = iv;
+
+            using var ms = new MemoryStream();
+            using (var cs = new CryptoStream(ms, aes.CreateDecryptor(), CryptoStreamMode.Write))
+            {
+                cs.Write(cipherText, 0, cipherText.Length);
+                cs.FlushFinalBlock();
+            }
+            return ms.ToArray();
+        }
+
+        // Legacy read path: AES-256-CBC, key+IV both derived via PBKDF2-SHA1/1000 from the static salt.
+        private static byte[] AES_Decrypt_Legacy(byte[] bytesToBeDecrypted, byte[] passwordBytes)
+        {
+            byte[] decryptedBytes;
+            using (var AES = Aes.Create())
+            {
+                AES.KeySize = 256;
+                AES.BlockSize = 128;
+
+                AES.Key = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1, AES.KeySize / 8);
+                AES.IV = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, saltBytes, 1000, HashAlgorithmName.SHA1, AES.BlockSize / 8);
+
+                AES.Mode = CipherMode.CBC;
+
+                using var ms = new MemoryStream();
+                using (var cs = new CryptoStream(ms, AES.CreateDecryptor(), CryptoStreamMode.Write))
+                {
+                    cs.Write(bytesToBeDecrypted, 0, bytesToBeDecrypted.Length);
+                    cs.Close();
+                }
+                decryptedBytes = ms.ToArray();
             }
 
             return decryptedBytes;


### PR DESCRIPTION
- log secret redaction
- stronger settings crypto
- secure-by-default TLS

Phase 1+2 - Centralized secret redaction in logs:
- Promote ConnectionStringRedactor to public with MaskKey/MaskPassword/RedactConnectionString
- Mask keys (first 4 chars + x), passwords (first+last + x), conn-string secrets at all log sites
- Batch SAS token no longer logged (storage account name only); KeyVault logs exception type/message

Phase 3 - Strengthen settings-file encryption (Cryptography.cs):
- New authenticated format: version byte + random salt + random IV + ciphertext + HMAC
- PBKDF2-SHA256 100k iterations, encrypt-then-MAC; legacy read path retained for backward compat

Phase 4 - TLS secure-by-default:
- New --trustservercertificate/--trustcert flag (default false); certs validated by default
- Added to settings JSON (AuthenticationArgs) and documented in CHANGELOG/README/commandline.md
- Process-wide ambient default ConnectionHelper.TrustServerCertificate seeded by the binder; connData carries the operator's intent through the threaded build, validation, and backout paths

Docs: CHANGELOG, README Security section, commandline.md flag reference.