### PR TITLE
Feature/aci test refactor

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ dotnet publish ./src/SqlBuildManager.Console/sbm.csproj -r linux-x64 --configura
 - `*.Dependent.PostgreSQL.UnitTest.csproj` - PostgreSQL-specific dependent tests (require PostgreSQL instance)
 - `SqlBuildManager.Console.ExternalTest` - Integration tests for SQL Server requiring Azure resources (run `azd up` first to provision resources)
 - `SqlBuildManager.Console.PostgreSQL.ExternalTest` - Integration tests for PostgreSQL requiring Azure resources
-- External tests run in ACI containers via `scripts/tests/run_all_external_tests_in_aci.ps1` using `src/Dockerfile.tests`
+- External tests run in ACI containers via `scripts/tests/run_all_sqlserver_external_tests_in_aci.ps1` and `scripts/tests/run_all_postgres_external_tests_in_aci.ps1` using `src/Dockerfile.tests`
 
 ## Architecture Overview
 

--- a/Build_Images.bat
+++ b/Build_Images.bat
@@ -4,7 +4,7 @@
 setlocal
 
 set "PWSH=C:\Program Files\PowerShell\7\pwsh.exe"
-set "WD=C:\Users\mimcke\source\repos\SqlBuildManager\scripts\ContainerRegistry"
+set "WD=D:\repos\SqlBuildManager\scripts\ContainerRegistry"
 
 
 wt.exe -w new ^
@@ -13,7 +13,7 @@ wt.exe -w new ^
   ; new-tab -p "PowerShell" --title "Runtime_Img"   -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\build_runtime_image_fromprefix.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"
 
 
-set "WD=C:\Users\mimcke\source\repos\SqlBuildManager\scripts\tests"
+set "WD=D:\repos\SqlBuildManager\scripts\tests"
 wt.exe -w new ^
   new-tab -p "PowerShell" --title "External_Img"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
   ; new-tab -p "PowerShell" --title "Dependent_Img" -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_dependent_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"

--- a/Build_Images.bat
+++ b/Build_Images.bat
@@ -15,7 +15,8 @@ wt.exe -w new ^
 
 set "WD=D:\repos\SqlBuildManager\scripts\tests"
 wt.exe -w new ^
-  new-tab -p "PowerShell" --title "External_Img"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
+  new-tab -p "PowerShell" --title "SqlServer_External"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_sqlserver_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
+  ; new-tab -p "PowerShell" --title "Postgres_External"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_postgres_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
   ; new-tab -p "PowerShell" --title "Dependent_Img" -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_dependent_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"
 
 endlocal

--- a/container_prompts.bat
+++ b/container_prompts.bat
@@ -4,7 +4,7 @@
 setlocal
 
 set "PWSH=C:\Program Files\PowerShell\7\pwsh.exe"
-set "WD=C:\Users\mimcke\source\repos\SqlBuildManager\scripts\ContainerRegistry"
+set "WD=D:\repos\SqlBuildManager\scripts\ContainerRegistry"
 
 
 wt.exe -w new ^
@@ -13,7 +13,7 @@ wt.exe -w new ^
   ; new-tab -p "PowerShell" --title "Runtime_Img"   -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\build_runtime_image_fromprefix.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"
 
 
-set "WD=C:\Users\mimcke\source\repos\SqlBuildManager\scripts\tests"
+set "WD=D:\repos\SqlBuildManager\scripts\tests"
 wt.exe -w new ^
   new-tab -p "PowerShell" --title "External_Img"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
   ; new-tab -p "PowerShell" --title "Dependent_Img" -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_dependent_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"

--- a/container_prompts.bat
+++ b/container_prompts.bat
@@ -15,7 +15,8 @@ wt.exe -w new ^
 
 set "WD=D:\repos\SqlBuildManager\scripts\tests"
 wt.exe -w new ^
-  new-tab -p "PowerShell" --title "External_Img"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
-  ; new-tab -p "PowerShell" --title "Dependent_Img" -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_dependent_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"
+  new-tab -p "PowerShell" --title "SqlServer_External_Tests"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_sqlserver_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
+  ; new-tab -p "PowerShell" --title "Postgres_External_Tests"  -d "%WD%" -- "%PWSH%" -NoExit  -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_all_postgres_external_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan" ^
+  ; new-tab -p "PowerShell" --title "Dependent_Tests" -d "%WD%" -- "%PWSH%" -NoExit -Command "ls\; Set-PSReadLineKeyHandler -Key F12 -ScriptBlock { [Microsoft.PowerShell.PSConsoleReadLine]::Insert('.\run_dependent_tests_in_aci.ps1 -prefix ') }\; Write-Host ''\; Write-Host 'Press F12 to load command at prompt' -ForegroundColor Cyan"
 
 endlocal

--- a/scripts/Database/grant_identity_permissions.ps1
+++ b/scripts/Database/grant_identity_permissions.ps1
@@ -158,13 +158,47 @@ BEGIN
 END
 "@
 
-        try {
-            # Execute SQL using the access token
-            Invoke-Sqlcmd -ServerInstance $serverFqdn -Database $dbName -AccessToken $accessToken -Query $sql -ErrorAction Stop
-            Write-Host "    ✓ Granted $databaseRole to $identityName" -ForegroundColor Green
+        $maxRetries = 3
+        $retryCount = 0
+        $success = $false
+
+        while (-not $success -and $retryCount -lt $maxRetries) {
+            try {
+                # Execute SQL using the access token
+                Invoke-Sqlcmd -ServerInstance $serverFqdn -Database $dbName -AccessToken $accessToken -Query $sql -ErrorAction Stop
+                Write-Host "    ✓ Granted $databaseRole to $identityName" -ForegroundColor Green
+                $success = $true
+            }
+            catch {
+                $errorMessage = $_.Exception.Message
+                
+                # Check if the error is due to blocked IP address
+                if ($errorMessage -match "Client with IP address '([0-9\.]+)' is not allowed") {
+                    $blockedIp = $matches[1]
+                    Write-Host "    ⚠ Connection blocked for IP: $blockedIp" -ForegroundColor Yellow
+                    Write-Host "    Adding IP $blockedIp to firewall rules..." -ForegroundColor Yellow
+                    
+                    # Add the blocked IP to firewall rules
+                    $dynamicRuleName = "GrantIdentityPermissions_Dynamic_$blockedIp"
+                    az sql server firewall-rule create --resource-group $resourceGroupName --server $server.name --name $dynamicRuleName --start-ip-address $blockedIp --end-ip-address $blockedIp --output none 2>$null
+                    
+                    # Wait for firewall rule to propagate
+                    Write-Host "    Waiting for firewall rule to propagate..." -ForegroundColor Yellow
+                    Start-Sleep -Seconds 5
+                    
+                    $retryCount++
+                    Write-Host "    Retrying ($retryCount/$maxRetries)..." -ForegroundColor Yellow
+                }
+                else {
+                    # Different error, don't retry
+                    Write-Host "    ✗ Failed to grant permissions: $errorMessage" -ForegroundColor Red
+                    break
+                }
+            }
         }
-        catch {
-            Write-Host "    ✗ Failed to grant permissions: $_" -ForegroundColor Red
+
+        if (-not $success -and $retryCount -ge $maxRetries) {
+            Write-Host "    ✗ Failed after $maxRetries retries" -ForegroundColor Red
         }
     }
 }
@@ -172,8 +206,18 @@ END
 # Clean up temporary firewall rules
 Write-Host "`nCleaning up temporary firewall rules..." -ForegroundColor DarkGreen
 foreach ($server in $sqlServers) {
+    # Remove the main temporary firewall rule
     az sql server firewall-rule delete --resource-group $resourceGroupName --server $server.name --name $firewallRuleName --output none 2>$null
     Write-Host "  Removed firewall rule from $($server.name)" -ForegroundColor DarkGreen
+    
+    # Remove any dynamically created firewall rules
+    $allRules = az sql server firewall-rule list --resource-group $resourceGroupName --server $server.name --query "[?starts_with(name, 'GrantIdentityPermissions_Dynamic_')].name" -o tsv
+    if ($allRules) {
+        foreach ($ruleName in $allRules) {
+            az sql server firewall-rule delete --resource-group $resourceGroupName --server $server.name --name $ruleName --output none 2>$null
+            Write-Host "  Removed dynamic firewall rule: $ruleName" -ForegroundColor DarkGreen
+        }
+    }
 }
 
 Write-Host "`n========================================" -ForegroundColor Cyan

--- a/scripts/tests/run_all_postgres_external_tests_in_aci.ps1
+++ b/scripts/tests/run_all_postgres_external_tests_in_aci.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Runs all PostgreSQL integration test suites in ACI, filtered by deployed platforms.
+.DESCRIPTION
+    Reads AZD environment configuration to determine which compute platforms (ACI,
+    Batch, Container Apps, AKS) and PostgreSQL database platform are deployed. For
+    all available compute platforms, launches the filtered PostgreSQL external test
+    runner in ACI. After all tests complete, downloads results from Azure Storage
+    and invokes GitHub Copilot CLI to analyze the test output.
+.PARAMETER prefix
+    Environment name prefix. Can also be set via azd env AZURE_NAME_PREFIX.
+#>
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string] $prefix
+)
+
+# Resolve prefix: parameter > azd env AZURE_NAME_PREFIX
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    $prefix = azd env get-value AZURE_NAME_PREFIX 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($prefix)) {
+        $prefix = $null
+    } else {
+        Write-Host "Using prefix '$prefix' from azd environment variable AZURE_NAME_PREFIX" -ForegroundColor DarkGreen
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($prefix)) {
+    Write-Host "ERROR: The -prefix parameter is required." -ForegroundColor Red
+    Write-Host "  Provide it as a parameter:  .\run_all_postgres_external_tests_in_aci.ps1 -prefix <your-prefix>" -ForegroundColor Yellow
+    Write-Host "  Or set it in your azd environment:  azd env set AZURE_NAME_PREFIX <your-prefix>" -ForegroundColor Yellow
+    exit 1
+}
+
+$exitCode = 0
+$timestamp = (Get-Date -Format 'yyyy-MM-dd-HHmmss')
+Clear-Host
+
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host "PostgreSQL Integration Test Runners (ACI in VNet)" -ForegroundColor Cyan
+Write-Host "============================================" -ForegroundColor Cyan
+
+#############################################
+# Load AZD deployment configuration
+#############################################
+Write-Host ""
+Write-Host "Loading AZD deployment configuration..." -ForegroundColor Cyan
+
+$azdConfig = @{}
+$azdOutput = azd env get-values 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "WARNING: Failed to load AZD environment values. All tests will be attempted." -ForegroundColor Yellow
+    Write-Host "  Run 'azd env select' or 'azd init' to configure an environment." -ForegroundColor Yellow
+    Write-Host ""
+} else {
+    $azdOutput | ForEach-Object {
+        if ($_ -match '^([^=]+)="?([^"]*)"?$') {
+            $azdConfig[$matches[1]] = $matches[2]
+        }
+    }
+}
+
+function Test-DeployFlag {
+    param([string[]]$flagNames)
+    if ($azdConfig.Count -eq 0) { return $true } # If no AZD config, assume all available
+    foreach ($flag in $flagNames) {
+        if ($azdConfig[$flag] -eq 'true') { return $true }
+    }
+    return $false
+}
+
+$hasAci          = Test-DeployFlag 'DEPLOY_ACI'
+$hasBatch        = Test-DeployFlag 'DEPLOY_BATCH_ACCOUNT', 'DEPLOY_BATCH'
+$hasContainerApp = Test-DeployFlag 'DEPLOY_CONTAINERAPP_ENV', 'DEPLOY_CONTAINERAPP'
+$hasAks          = Test-DeployFlag 'DEPLOY_AKS'
+$hasPostgreSQL   = Test-DeployFlag 'DEPLOY_POSTGRESQL'
+
+Write-Host ""
+Write-Host "Platform Availability:" -ForegroundColor Cyan
+Write-Host "  PostgreSQL:     $(if ($hasPostgreSQL)   { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasPostgreSQL)   { 'Green' } else { 'DarkGray' })
+Write-Host "  ACI:            $(if ($hasAci)           { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasAci)           { 'Green' } else { 'DarkGray' })
+Write-Host "  Batch:          $(if ($hasBatch)         { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasBatch)         { 'Green' } else { 'DarkGray' })
+Write-Host "  Container Apps: $(if ($hasContainerApp)  { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasContainerApp)  { 'Green' } else { 'DarkGray' })
+Write-Host "  AKS:            $(if ($hasAks)           { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasAks)           { 'Green' } else { 'DarkGray' })
+Write-Host ""
+
+#############################################
+# PostgreSQL tests (requires PostgreSQL + dynamically filters by available compute)
+#############################################
+
+if (-not $hasPostgreSQL) {
+    Write-Host "SKIPPING [pg]: PostgreSQL database is not deployed" -ForegroundColor Yellow
+} else {
+    # Build filter dynamically based on available compute platforms
+    $pgFilters = @()
+    $pgSkipped = @()
+
+    if ($hasAci) {
+        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.AciTests"
+    } else {
+        $pgSkipped += "ACI"
+    }
+    if ($hasBatch) {
+        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.BatchTests"
+    } else {
+        $pgSkipped += "Batch"
+    }
+    if ($hasContainerApp) {
+        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.ContainerAppTests"
+    } else {
+        $pgSkipped += "Container Apps"
+    }
+    if ($hasAks) {
+        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.KubernetesTests"
+    } else {
+        $pgSkipped += "AKS"
+    }
+
+    if ($pgSkipped.Count -gt 0) {
+        Write-Host "SKIPPING PostgreSQL tests for unavailable compute: $($pgSkipped -join ', ')" -ForegroundColor Yellow
+    }
+
+    if ($pgFilters.Count -gt 0) {
+        $pgTestFilter = $pgFilters -join '|'
+        .\run_filtered_external_tests_in_aci.ps1 -prefix $prefix -customName pg -testFilter $pgTestFilter -timeoutMinutes 300 -timestamp $timestamp
+        $exitCode += $LASTEXITCODE
+    } else {
+        Write-Host "SKIPPING [pg]: No compute platforms available for PostgreSQL tests" -ForegroundColor Yellow
+    }
+}
+
+# Download test results
+if ((Test-Path ./testresults) -eq $false) { mkdir testresults }
+az storage blob download-batch --account-name "$($prefix)storage" --source testresults --pattern "$($timestamp)*" --destination ./testresults --auth-mode login --overwrite
+
+# Analyze test results with GitHub Copilot
+$promptTemplate = Get-Content -Path "$PSScriptRoot\analyze-test-results-prompt.md" -Raw
+$prompt = $promptTemplate -replace '\{\{timestamp\}\}', $timestamp
+$output = copilot --yolo -p $prompt 2>&1
+

--- a/scripts/tests/run_all_sqlserver_external_tests_in_aci.ps1
+++ b/scripts/tests/run_all_sqlserver_external_tests_in_aci.ps1
@@ -1,19 +1,19 @@
 <#
 .SYNOPSIS
-    Runs all integration test suites in ACI, filtered by deployed platforms.
+    Runs all SQL Server integration test suites in ACI, filtered by deployed platforms.
 .DESCRIPTION
     Reads AZD environment configuration to determine which compute platforms (ACI,
-    Batch, Container Apps, AKS) and database platforms (SQL Server, PostgreSQL) are
-    deployed. For each available combination, launches the filtered external test
-    runner in ACI. After all tests complete, downloads results from Azure Storage
-    and invokes GitHub Copilot CLI to analyze the test output.
+    Batch, Container Apps, AKS) and SQL Server database platform are deployed. For
+    each available combination, launches the filtered external test runner in ACI.
+    After all tests complete, downloads results from Azure Storage and invokes
+    GitHub Copilot CLI to analyze the test output.
 .PARAMETER prefix
     Environment name prefix. Can also be set via azd env AZURE_NAME_PREFIX.
 #>
 [CmdletBinding()]
 param (
     [Parameter()]
-    [string] $prefix 
+    [string] $prefix
 )
 
 # Resolve prefix: parameter > azd env AZURE_NAME_PREFIX
@@ -28,17 +28,17 @@ if ([string]::IsNullOrWhiteSpace($prefix)) {
 
 if ([string]::IsNullOrWhiteSpace($prefix)) {
     Write-Host "ERROR: The -prefix parameter is required." -ForegroundColor Red
-    Write-Host "  Provide it as a parameter:  .\run_all_external_tests_in_aci.ps1 -prefix <your-prefix>" -ForegroundColor Yellow
+    Write-Host "  Provide it as a parameter:  .\run_all_sqlserver_external_tests_in_aci.ps1 -prefix <your-prefix>" -ForegroundColor Yellow
     Write-Host "  Or set it in your azd environment:  azd env set AZURE_NAME_PREFIX <your-prefix>" -ForegroundColor Yellow
     exit 1
 }
 
 $exitCode = 0
 $timestamp = (Get-Date -Format 'yyyy-MM-dd-HHmmss')
-Clear-Host 
+Clear-Host
 
 Write-Host "============================================" -ForegroundColor Cyan
-Write-Host "Integration Test Runners (ACI in VNet)" -ForegroundColor Cyan
+Write-Host "SQL Server Integration Test Runners (ACI in VNet)" -ForegroundColor Cyan
 Write-Host "============================================" -ForegroundColor Cyan
 
 #############################################
@@ -75,12 +75,10 @@ $hasBatch        = Test-DeployFlag 'DEPLOY_BATCH_ACCOUNT', 'DEPLOY_BATCH'
 $hasContainerApp = Test-DeployFlag 'DEPLOY_CONTAINERAPP_ENV', 'DEPLOY_CONTAINERAPP'
 $hasAks          = Test-DeployFlag 'DEPLOY_AKS'
 $hasSqlServer    = Test-DeployFlag 'DEPLOY_SQLSERVER'
-$hasPostgreSQL   = Test-DeployFlag 'DEPLOY_POSTGRESQL'
 
 Write-Host ""
 Write-Host "Platform Availability:" -ForegroundColor Cyan
 Write-Host "  SQL Server:     $(if ($hasSqlServer)    { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasSqlServer)    { 'Green' } else { 'DarkGray' })
-Write-Host "  PostgreSQL:     $(if ($hasPostgreSQL)   { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasPostgreSQL)   { 'Green' } else { 'DarkGray' })
 Write-Host "  ACI:            $(if ($hasAci)           { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasAci)           { 'Green' } else { 'DarkGray' })
 Write-Host "  Batch:          $(if ($hasBatch)         { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasBatch)         { 'Green' } else { 'DarkGray' })
 Write-Host "  Container Apps: $(if ($hasContainerApp)  { 'Deployed' } else { 'Not deployed' })" -ForegroundColor $(if ($hasContainerApp)  { 'Green' } else { 'DarkGray' })
@@ -97,16 +95,16 @@ function Invoke-TestIfAvailable {
         [bool]$databaseAvailable,
         [int]$timeoutMinutes = 300
     )
-    
+
     $skipReasons = @()
     if (-not $computeAvailable) { $skipReasons += "$computeLabel compute is not deployed" }
     if (-not $databaseAvailable) { $skipReasons += "$databaseLabel database is not deployed" }
-    
+
     if ($skipReasons.Count -gt 0) {
         Write-Host "SKIPPING [$customName]: $($skipReasons -join '; ')" -ForegroundColor Yellow
         return 0
     }
-    
+
     .\run_filtered_external_tests_in_aci.ps1 -prefix $prefix -customName $customName -testFilter $testFilter -timeoutMinutes $timeoutMinutes -timestamp $timestamp
     return $LASTEXITCODE
 }
@@ -135,55 +133,6 @@ $exitCode += Invoke-TestIfAvailable -customName "aks" `
     -computeLabel "AKS" -computeAvailable $hasAks `
     -databaseLabel "SQL Server" -databaseAvailable $hasSqlServer
 
-#############################################
-# PostgreSQL tests (requires PostgreSQL + dynamically filters by available compute)
-#############################################
-
-if (-not $hasPostgreSQL) {
-    Write-Host "SKIPPING [pg]: PostgreSQL database is not deployed" -ForegroundColor Yellow
-} else {
-    # Build filter dynamically based on available compute platforms
-    $pgFilters = @()
-    $pgSkipped = @()
-
-    if ($hasAci) {
-        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.AciTests"
-    } else {
-        $pgSkipped += "ACI"
-    }
-    if ($hasBatch) {
-        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.BatchTests"
-    } else {
-        $pgSkipped += "Batch"
-    }
-    if ($hasContainerApp) {
-        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.ContainerAppTests"
-    } else {
-        $pgSkipped += "Container Apps"
-    }
-    if ($hasAks) {
-        $pgFilters += "FullyQualifiedName~SqlBuildManager.Console.PostgreSQL.ExternalTest.KubernetesTests"
-    } else {
-        $pgSkipped += "AKS"
-    }
-
-    if ($pgSkipped.Count -gt 0) {
-        Write-Host "SKIPPING PostgreSQL tests for unavailable compute: $($pgSkipped -join ', ')" -ForegroundColor Yellow
-    }
-
-    if ($pgFilters.Count -gt 0) {
-        $pgTestFilter = $pgFilters -join '|'
-        .\run_filtered_external_tests_in_aci.ps1 -prefix $prefix -customName pg -testFilter $pgTestFilter -timeoutMinutes 300 -timestamp $timestamp
-        $exitCode += $LASTEXITCODE
-    } else {
-        Write-Host "SKIPPING [pg]: No compute platforms available for PostgreSQL tests" -ForegroundColor Yellow
-    }
-}
-
-#############################################
-# Additional SQL Server Batch tests
-#############################################
-
 $exitCode += Invoke-TestIfAvailable -customName "batchoverride" `
     -testFilter "FullyQualifiedName~SqlBuildManager.Console.ExternalTest.BatchTests.Batch_Override" `
     -computeLabel "Batch" -computeAvailable $hasBatch `
@@ -194,12 +143,11 @@ $exitCode += Invoke-TestIfAvailable -customName "batchquery" `
     -computeLabel "Batch" -computeAvailable $hasBatch `
     -databaseLabel "SQL Server" -databaseAvailable $hasSqlServer
 
+# Download test results
+if ((Test-Path ./testresults) -eq $false) { mkdir testresults }
+az storage blob download-batch --account-name "$($prefix)storage" --source testresults --pattern "$($timestamp)*" --destination ./testresults --auth-mode login --overwrite
 
-# Download test results 
-if( (Test-Path ./testresults) -eq $false) { mkdir testresults }
-az storage blob download-batch --account-name "$($prefix)storage" --source testresults --pattern "$($timestamp)*" --destination ./testresults  --auth-mode login --overwrite
-
-    # Analyze test results with GitHub Copilot
+# Analyze test results with GitHub Copilot
 $promptTemplate = Get-Content -Path "$PSScriptRoot\analyze-test-results-prompt.md" -Raw
 $prompt = $promptTemplate -replace '\{\{timestamp\}\}', $timestamp
 $output = copilot --yolo -p $prompt 2>&1


### PR DESCRIPTION
This pull request refactors and extends the external integration test automation for SQL Server and PostgreSQL, improves test script reliability, and updates documentation and helper scripts to match the new structure. The main improvements are the separation of SQL Server and PostgreSQL external test runners, enhanced dynamic firewall handling, and corresponding updates to helper scripts and documentation.

**Test runner separation and enhancements:**

* Split the previous combined test runner `run_all_external_tests_in_aci.ps1` into two scripts: `run_all_sqlserver_external_tests_in_aci.ps1` (for SQL Server) and the new `run_all_postgres_external_tests_in_aci.ps1` (for PostgreSQL), each dynamically filtering tests based on deployed platforms. The SQL Server script was renamed and PostgreSQL logic was moved to its own script. [[1]](diffhunk://#diff-ca24e1619e06d4bda229207de58abfb0ba6ae6ecbc8ea0f39bccdc563024fdf0L3-R9) [[2]](diffhunk://#diff-12f1a8f6660b1212fabd60b35a3b84c8e692c411180d1e84bd95245416c45cbaR1-R141)
* Updated the SQL Server test runner to focus only on SQL Server tests, removing all PostgreSQL logic and related platform checks. [[1]](diffhunk://#diff-ca24e1619e06d4bda229207de58abfb0ba6ae6ecbc8ea0f39bccdc563024fdf0L78-L83) [[2]](diffhunk://#diff-ca24e1619e06d4bda229207de58abfb0ba6ae6ecbc8ea0f39bccdc563024fdf0L138-L186)
* The new PostgreSQL test runner script dynamically determines which compute platforms are available and only runs the relevant PostgreSQL tests, skipping unavailable combinations with clear messaging.

**Firewall and reliability improvements:**

* Improved `grant_identity_permissions.ps1` to automatically detect and add blocked client IP addresses to the firewall, retry permission grants up to three times, and clean up any dynamically-created firewall rules after execution.

**Helper script and documentation updates:**

* Updated `Build_Images.bat` and `container_prompts.bat` to point to the new, separate SQL Server and PostgreSQL test runner scripts, and adjusted working directory paths to a new location. [[1]](diffhunk://#diff-4a8c31d774640e772a5a17290bb99fbdef8036cfed3ba7c745c2b5075388150aL7-R7) [[2]](diffhunk://#diff-4a8c31d774640e772a5a17290bb99fbdef8036cfed3ba7c745c2b5075388150aL16-R19) [[3]](diffhunk://#diff-10f9391a8beca30030269a18a697328f604ecf74c810c0e2ef4649d135284854L7-R7) [[4]](diffhunk://#diff-10f9391a8beca30030269a18a697328f604ecf74c810c0e2ef4649d135284854L16-R20)
* Updated `.github/copilot-instructions.md` to document the new test runner scripts and clarify how external tests are executed.

These changes make the test automation more modular, robust, and easier to maintain.
[Copilot is generating a summary...]