### PR TITLE
Restore release container vulnerability scanning

### DIFF
--- a/.github/workflows/container-release-build.yml
+++ b/.github/workflows/container-release-build.yml
@@ -15,6 +15,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -28,6 +30,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build release container for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:src"
+          platforms: linux/amd64
+          load: true
+          pull: true
+          no-cache: true
+          tags: sqlbuildmanager:release-scan
+      -
+        name: Scan release container
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: sqlbuildmanager:release-scan
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
       -
         name: Build and push to GitHub Container Registry
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Release container publishing no longer scanned the image before pushing it. This restores a blocking Trivy scan so HIGH and CRITICAL vulnerabilities stop the release before GHCR or Docker Hub publication.

The workflow now explicitly checks out the published release tag and builds a fresh image with `pull: true` and `no-cache: true` for scanning, while preserving the existing GHCR and Docker Hub publishing flow.