### PR TITLE
Fix ACI external test runner selection

### DIFF
--- a/container_prompts.bat
+++ b/container_prompts.bat
@@ -38,6 +38,7 @@ set "WD=%REPO_ROOT%\scripts\tests"
 wt.exe -w new ^
   new-tab --title "SqlServer_External_Tests" -d "%WD%" -- "%PWSH%" -NoExit -File "%TAB_INIT%" -CommandText ".\run_all_sqlserver_external_tests_in_aci.ps1 -envName " ^
   ; new-tab --title "Postgres_External_Tests" -d "%WD%" -- "%PWSH%" -NoExit -File "%TAB_INIT%" -CommandText ".\run_all_postgres_external_tests_in_aci.ps1 -envName " ^
+  ; new-tab --title "MySQL_External_Tests" -d "%WD%" -- "%PWSH%" -NoExit -File "%TAB_INIT%" -CommandText ".\run_all_mysql_external_tests_in_aci.ps1 -envName " ^
   ; new-tab --title "Dependent_Tests" -d "%WD%" -- "%PWSH%" -NoExit -File "%TAB_INIT%" -CommandText ".\run_dependent_tests_in_aci.ps1 -envName "
 
 endlocal

--- a/scripts/tests/run_filtered_external_tests_in_aci.ps1
+++ b/scripts/tests/run_filtered_external_tests_in_aci.ps1
@@ -135,7 +135,7 @@ Write-Debug "Using Container Registry: $acrLoginServer"
 #############################################
 # Build and push test image if requested
 #############################################
-# if (-not $buildImage -and $testFilter -like "*MySQL.ExternalTest*") {
+# if (-not $buildImage -and $testFilter -like "*MySQL.AzureTest*") {
 #     $mySqlAuthMode = azd env get-value MYSQL_AUTH_MODE 2>$null
 #     if ($LASTEXITCODE -eq 0 -and $mySqlAuthMode -eq "Password") {
 #         Write-Host "MYSQL_AUTH_MODE=Password detected for MySQL external tests; enabling -buildImage to avoid stale ManagedIdentity test image reuse." -ForegroundColor Yellow
@@ -198,9 +198,9 @@ $blobPath = "$timestamp/$testContainerName"
 # Use tee to capture console output to a log file while still displaying it
 
 # Determine which test DLL to run based on the filter
-if ($testFilter -like "*PostgreSQL.ExternalTest*") {
+if ($testFilter -like "*PostgreSQL.AzureTest*") {
     $testDll = "SqlBuildManager.Console.PostgreSQL.AzureTest.dll"
-} elseif ($testFilter -like "*MySQL.ExternalTest*") {
+} elseif ($testFilter -like "*MySQL.AzureTest*") {
     $testDll = "SqlBuildManager.Console.MySQL.AzureTest.dll"
 } else {
     $testDll = "SqlBuildManager.Console.SqlServer.AzureTest.dll"
@@ -217,7 +217,7 @@ $uploadCmd = "az storage blob upload-batch --account-name $storageAccountName --
 
 # Build Kubernetes pre-requisite commands if test filter contains "Kubernetes"
 $aksPreCmd = ""
-if ($testFilter -like "*Kubernetes*" -or $testFilter -like "*PostgreSQL.ExternalTest*" -or $testFilter -like "*MySQL.ExternalTest*") {
+if ($testFilter -like "*Kubernetes*") {
     $aksPreCmd = "az aks install-cli; az aks get-credentials --resource-group $resourceGroupName --name $aksClusterName --overwrite-existing; "
     Write-Debug "Kubernetes tests detected - will install kubectl and get AKS credentials"
 }


### PR DESCRIPTION
## Summary
- select the PostgreSQL and MySQL AzureTest assemblies when running filtered external tests in ACI
- only prepare AKS credentials for Kubernetes test filters
- add a MySQL external-test tab to `container_prompts.bat`

## Validation
- PowerShell parser validation passed
- `git diff --check` passed